### PR TITLE
feat: improve note editing and accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist-ssr
 !AGENTS.md
 !CLAUDE.md
 !CONTRIBUTING.md
+!brand.md
 
 # Secrets and keys (never commit these!)
 *.key

--- a/brand.md
+++ b/brand.md
@@ -1,0 +1,124 @@
+# Brand: Markd
+
+Markd is a fast, local-first Markdown notes app.
+
+_Established on 2026-07-12. This file documents the existing product system._
+
+## Palette: Markd Monochrome
+
+**Vibe:** calm, premium, focused
+**Category:** consumer productivity
+**Mood:** calm and premium
+
+Markd uses warm neutral surfaces and typographic contrast instead of a brand
+accent. Color appears only when it communicates destructive state.
+
+### Core seeds
+
+| Role | Light | Dark |
+| --- | --- | --- |
+| Background | `#fbfbfa` | `#1a1a1a` |
+| Panel | `#f4f4f2` | `#151515` |
+| Recessed | `#e9e9e6` | `#0f0f0f` |
+| Primary text | `#191919` | `#ebebe8` |
+| Secondary text | `#6e6e6a` | `#8f8f8a` |
+| Faint text | `#a3a39e` | `#64645f` |
+| Border | `#e3e3e0` | `#292927` |
+| Inverted surface | `#1c1c1c` | `#ebebe8` |
+| Inverted text | `#fbfbfa` | `#131313` |
+| Destructive | `#b3261e` | `#e5484d` |
+
+### Semantic tokens
+
+Use the tokens defined in `src/styles.css`:
+
+- `bg`, `panel`, and `sunken` for the surface hierarchy.
+- `ink`, `muted`, and `faint` for the text hierarchy.
+- `line` and `line-soft` for separation.
+- `hover` and `active` for interaction feedback.
+- `invert` and `invert-ink` for selected rows and primary actions.
+- `danger` only for destructive actions and failures.
+
+Never hardcode colors in components. New beUI or shadcn components must use
+the compatibility mappings already defined in `src/styles.css`.
+
+## Typography: Inter and JetBrains Mono
+
+- **Interface and reading:** Inter Variable
+- **Code, paths, shortcuts, and raw Markdown:** JetBrains Mono Variable
+
+### Type hierarchy
+
+| Role | Guidance |
+| --- | --- |
+| Product display | 64 px, weight 680, welcome screen only |
+| Note title | 30 px, weight 680 |
+| Editor H1 | 1.6 em, weight 620 |
+| Editor H2 | 1.3 em, weight 580 |
+| Editor H3 | 1.1 em, weight 560 |
+| Editor H4 | 1 em, weight 550 |
+| Reading text | 16 px, line-height 1.65 |
+| Interface text | 12.5 to 14 px |
+| Caption | 11 to 12 px, only when contrast remains readable |
+
+Use tight tracking only for display and larger headings. Body copy stays
+neutral and comfortable.
+
+## Shape and depth
+
+- Buttons use medium corners.
+- Cards and dialogs use large corners.
+- The tab strip uses the recessed `sunken` surface.
+- Selected rows use the inverted treatment when strong selection is needed.
+- Prefer borders for structure. Reserve shadows for floating overlays.
+- Keep all motion between 100 and 160 ms unless a shared spring controls it.
+
+## Tone and voice
+
+### Use
+
+Write with calm confidence. Keep sentences short and specific. Describe what
+happened, where content lives, and what the user can do next.
+
+Examples:
+
+- "Plain Markdown notes. Yours, on disk."
+- "Moved to Trash."
+- "Note exported."
+- "Choose a folder for your vault."
+
+### Avoid
+
+- Urgency, hype, or exaggerated claims.
+- Words such as revolutionary, seamless, powerful, unlock, and effortless.
+- Exclamation marks except for genuine warnings.
+- Jokes inside errors or destructive confirmations.
+- Audience labels in core product copy.
+
+## Accessibility
+
+- Every interactive control must be keyboard reachable.
+- Composite controls use arrow-key navigation.
+- Every focusable control has a visible focus indicator using `ink` or
+  `invert`, not the low-contrast `faint` token.
+- Modals trap focus, close with Escape, and restore focus to their trigger.
+- Icon-only controls require an accessible label.
+- Motion respects reduced-motion preferences.
+
+## Do
+
+- Preserve the strict monochrome system.
+- Use spacing in 4 px increments where practical.
+- Keep interface density compact but readable.
+- Test every change in light and dark modes.
+- Reuse existing primitives and motion tokens.
+
+## Do not
+
+- Add decorative accent colors.
+- Add gradients, glass effects, or heavy shadows.
+- Mix icon libraries or stroke styles.
+- Use long promotional copy in the application.
+- Use em dashes in product copy or documentation.
+
+_Last updated: 2026-07-12. Palette: Markd Monochrome. Typography: Inter and JetBrains Mono. Gradients: none._

--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,14 @@
     "": {
       "name": "usedraft",
       "dependencies": {
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.6",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@lezer/highlight": "^1.2.3",
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
@@ -85,6 +91,26 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.4", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.7.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.4", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.7", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg=="],
+
+    "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
+
+    "@codemirror/view": ["@codemirror/view@6.43.6", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
@@ -156,6 +182,22 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/css": ["@lezer/css@1.3.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.7.1", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-MEBZeFSBxgteUjEC3Wxg2Dwld5/JxRKG267L3bMFdibm8KjqSdiJYBeFw1Nt1CM8+zKMpSIEHblY8FD9z38sJQ=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -377,6 +419,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "crelt": ["crelt@1.0.7", "", {}, "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -506,6 +550,8 @@
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.6",
+        "@dnd-kit/core": "^6.3.1",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@lezer/highlight": "^1.2.3",
@@ -111,6 +112,12 @@
     "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
 
     "@codemirror/view": ["@codemirror/view@6.43.6", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.9.0",
+        "@tiptap/extension-code-block": "3.23.6",
         "@tiptap/extension-image": "^3.23.6",
         "@tiptap/extension-link": "^3.23.6",
         "@tiptap/extension-placeholder": "^3.23.6",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.9.0",
+    "@tiptap/extension-code-block": "3.23.6",
     "@tiptap/extension-image": "^3.23.6",
     "@tiptap/extension-link": "^3.23.6",
     "@tiptap/extension-placeholder": "^3.23.6",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,14 @@
     "release": "bash scripts/release.sh"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@lezer/highlight": "^1.2.3",
     "@tailwindcss/vite": "^4.1.18",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
+    "@dnd-kit/core": "^6.3.1",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@lezer/highlight": "^1.2.3",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -346,6 +346,45 @@ pub async fn export_bookmarks(
     Ok(Some(path.display().to_string()))
 }
 
+/// Export the current note contents to a markdown file chosen by the user.
+/// The frontend supplies its live editor contents so an in-flight autosave
+/// cannot make the exported copy stale.
+#[tauri::command]
+pub async fn export_note(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    rel: String,
+    content: String,
+) -> AppResult<Option<String>> {
+    // Validate that the source note still exists and `rel` stays in the vault.
+    notes::read_note(&state.root()?, &rel)?;
+    let file_name = PathBuf::from(&rel)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "note.md".to_string());
+
+    let picked = tauri::async_runtime::spawn_blocking({
+        let app = app.clone();
+        move || {
+            app.dialog()
+                .file()
+                .set_file_name(file_name)
+                .blocking_save_file()
+        }
+    })
+    .await
+    .map_err(|e| AppError::Other(e.to_string()))?;
+
+    let Some(dest) = picked else {
+        return Ok(None);
+    };
+    let path = dest
+        .into_path()
+        .map_err(|e| AppError::InvalidPath(e.to_string()))?;
+    std::fs::write(&path, content)?;
+    Ok(Some(path.display().to_string()))
+}
+
 /// Fetch title/preview-image/favicon for a bookmark and persist them.
 /// Marks the bookmark as fetched even on failure so the UI can offer retry
 /// without hammering the network on every load.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() {
             commands::bookmark_delete,
             commands::bookmark_fetch_meta,
             commands::export_bookmarks,
+            commands::export_note,
             commands::save_image_asset,
             commands::set_theme,
         ])

--- a/src/components/editor/CodeBlock.tsx
+++ b/src/components/editor/CodeBlock.tsx
@@ -1,0 +1,64 @@
+import CodeBlock from "@tiptap/extension-code-block";
+import {
+  NodeViewContent,
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { ActionSwapIcon } from "@/components/motion/action-swap";
+
+function CodeBlockView({ node }: NodeViewProps) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(node.textContent);
+    setCopied(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), 1400);
+  };
+
+  return (
+    <NodeViewWrapper className="code-block-wrap">
+      <pre>
+        <NodeViewContent<"code"> as="code" />
+      </pre>
+      <button
+        type="button"
+        contentEditable={false}
+        aria-label={copied ? "Copied" : "Copy code"}
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={copy}
+        className="code-block-copy"
+      >
+        <ActionSwapIcon
+          value={copied ? "copied" : "copy"}
+          animation="roll"
+          className="h-[13px] w-[13px]"
+        >
+          {copied ? (
+            <Check size={13} strokeWidth={2} />
+          ) : (
+            <Copy size={13} strokeWidth={2} />
+          )}
+        </ActionSwapIcon>
+        <span>{copied ? "Copied" : "Copy"}</span>
+      </button>
+    </NodeViewWrapper>
+  );
+}
+
+export const CodeBlockWithCopy = CodeBlock.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(CodeBlockView);
+  },
+});

--- a/src/components/editor/MarkdownSourceEditor.tsx
+++ b/src/components/editor/MarkdownSourceEditor.tsx
@@ -1,0 +1,114 @@
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  HighlightStyle,
+  syntaxHighlighting,
+} from "@codemirror/language";
+import { markdown } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import {
+  drawSelection,
+  EditorView,
+  highlightActiveLine,
+  keymap,
+} from "@codemirror/view";
+import { tags } from "@lezer/highlight";
+import { useEffect, useRef } from "react";
+
+const markdTheme = EditorView.theme({
+  "&": {
+    height: "100%",
+    backgroundColor: "transparent",
+    color: "var(--ink)",
+    fontFamily: '"JetBrains Mono Variable", monospace',
+    fontSize: "13px",
+  },
+  "&.cm-focused": { outline: "none" },
+  ".cm-scroller": {
+    overflow: "visible",
+    fontFamily: "inherit",
+    lineHeight: "1.5rem",
+  },
+  ".cm-content": {
+    minHeight: "calc(100vh - 190px)",
+    padding: "0 0 5rem",
+    caretColor: "var(--ink)",
+  },
+  ".cm-line": { padding: "0" },
+  ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--ink)" },
+  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+    backgroundColor: "var(--active)",
+  },
+  ".cm-activeLine": { backgroundColor: "color-mix(in srgb, var(--hover) 55%, transparent)" },
+});
+
+const markdHighlight = HighlightStyle.define([
+  { tag: tags.heading, color: "var(--ink)", fontWeight: "700" },
+  { tag: [tags.strong, tags.emphasis], color: "var(--ink)" },
+  { tag: tags.strong, fontWeight: "700" },
+  { tag: tags.emphasis, fontStyle: "italic" },
+  { tag: [tags.link, tags.url], color: "var(--muted)", textDecoration: "underline" },
+  { tag: [tags.monospace, tags.string], color: "var(--muted)" },
+  { tag: [tags.meta, tags.punctuation, tags.quote], color: "var(--faint)" },
+]);
+
+export function MarkdownSourceEditor({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const syncingRef = useRef(false);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    if (!hostRef.current) return;
+
+    const view = new EditorView({
+      parent: hostRef.current,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          history(),
+          drawSelection(),
+          highlightActiveLine(),
+          keymap.of([...defaultKeymap, ...historyKeymap]),
+          markdown(),
+          syntaxHighlighting(markdHighlight),
+          EditorView.lineWrapping,
+          markdTheme,
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged && !syncingRef.current) {
+              onChangeRef.current(update.state.doc.toString());
+            }
+          }),
+        ],
+      }),
+    });
+    viewRef.current = view;
+    view.focus();
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // The view owns its document after mount; prop synchronization is handled
+    // separately so React renders never recreate editor state or undo history.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || view.state.doc.toString() === value) return;
+    syncingRef.current = true;
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: value },
+    });
+    syncingRef.current = false;
+  }, [value]);
+
+  return <div ref={hostRef} className="min-h-[calc(100vh-190px)] w-full" />;
+}

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -1,6 +1,6 @@
 import { EditorContent, useEditor } from "@tiptap/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ipc } from "@/lib/ipc";
 import {
@@ -21,6 +21,12 @@ import { NoteLinkPicker, type LinkPickerState } from "./NoteLinkPicker";
 import { NoteProperties } from "./NoteProperties";
 import { SelectionMenu } from "./SelectionMenu";
 import { SlashMenu, type SlashMenuState } from "./SlashMenu";
+
+const MarkdownSourceEditor = lazy(() =>
+  import("./MarkdownSourceEditor").then((module) => ({
+    default: module.MarkdownSourceEditor,
+  })),
+);
 
 /**
  * One live Tiptap instance per mounted editor. Tab panes keep an instance per
@@ -466,14 +472,10 @@ export const NoteEditor = memo(function NoteEditor({
         )}
         <div className={cx(missing && "hidden")}>
           {markdownSource ? (
-            <textarea
-              value={rawText}
-              aria-label="Markdown source"
-              autoCapitalize="off"
-              autoCorrect="off"
-              spellCheck={false}
-              onChange={(event) => {
-                const text = event.target.value;
+            <Suspense fallback={null}>
+              <MarkdownSourceEditor
+                value={rawText}
+                onChange={(text) => {
                 setRawText(text);
                 const { frontmatter: fm, body } = splitFrontmatter(text);
                 frontmatter.current = fm;
@@ -483,8 +485,8 @@ export const NoteEditor = memo(function NoteEditor({
                 debouncedPersist(body);
                 setWords(countWords(body));
               }}
-              className="min-h-[calc(100vh-190px)] w-full resize-none bg-transparent pb-20 font-mono text-[13px] leading-6 text-ink outline-none placeholder:text-faint"
-            />
+              />
+            </Suspense>
           ) : (
             <>
               <NoteProperties properties={properties} />

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -46,12 +46,14 @@ export const NoteEditor = memo(function NoteEditor({
   const vaultRoot = useVault((s) => s.root);
   const renameEntry = useVault((s) => s.renameEntry);
   const setSaveState = useUi((s) => s.setSaveState);
+  const markdownSource = useUi((s) => s.markdownSource);
 
   const [slashMenu, setSlashMenu] = useState<SlashMenuState | null>(null);
   const [linkPicker, setLinkPicker] = useState<LinkPickerState | null>(null);
   const [words, setWords] = useState(0);
   const [missing, setMissing] = useState(false);
   const [properties, setProperties] = useState<Property[]>([]);
+  const [rawText, setRawText] = useState("");
 
   const relRef = useRef(rel);
   // Frontmatter of the loaded note, kept out of the editor and re-attached on
@@ -237,6 +239,7 @@ export const NoteEditor = memo(function NoteEditor({
         // text; rewrites only reach the file if the user edits the note.
         const { frontmatter: fm, body } = splitFrontmatter(text);
         frontmatter.current = fm;
+        setRawText(text);
         setProperties(parseFrontmatter(fm));
         const notes = flattenNotes(useVault.getState().tree);
         swapping.current = true;
@@ -248,7 +251,12 @@ export const NoteEditor = memo(function NoteEditor({
         // A freshly loaded note starts at the top.
         savedScroll.current = 0;
         if (scrollRef.current) scrollRef.current.scrollTop = 0;
-        if (body.length === 0 && activeRef.current) {
+        const titleFocus = useTabs.getState().titleFocusReq;
+        if (
+          body.length === 0 &&
+          activeRef.current &&
+          titleFocus?.rel !== rel
+        ) {
           editor.commands.focus("start");
         }
       })
@@ -260,6 +268,27 @@ export const NoteEditor = memo(function NoteEditor({
       cancelled = true;
     };
   }, [editor, rel, persist, debouncedPersist]);
+
+  const previousSource = useRef(markdownSource);
+  useEffect(() => {
+    if (!editor || previousSource.current === markdownSource) return;
+    previousSource.current = markdownSource;
+
+    if (markdownSource) {
+      setRawText(joinFrontmatter(frontmatter.current, editor.getMarkdown()));
+      return;
+    }
+
+    const { frontmatter: fm, body } = splitFrontmatter(rawText);
+    frontmatter.current = fm;
+    setProperties(parseFrontmatter(fm));
+    const notes = flattenNotes(useVault.getState().tree);
+    swapping.current = true;
+    editor.commands.setContent(wikiToMarkdown(body, notes), {
+      contentType: "markdown",
+    });
+    swapping.current = false;
+  }, [editor, markdownSource, rawText]);
 
   // Flush any unsaved edit when the editor unmounts (tab closed / view gone).
   useEffect(() => {
@@ -280,6 +309,7 @@ export const NoteEditor = memo(function NoteEditor({
       if (cur !== relRef.current || pending.current !== null) return;
       if (disk !== lastSaved.current) {
         lastSaved.current = disk;
+        setRawText(disk);
         const { frontmatter: fm, body } = splitFrontmatter(disk);
         frontmatter.current = fm;
         setProperties(parseFrontmatter(fm));
@@ -345,6 +375,7 @@ export const NoteEditor = memo(function NoteEditor({
 
   // Honor a scroll-to-top request for this note (fired when opened via a link).
   const scrollTopReq = useTabs((s) => s.scrollTopReq);
+  const titleFocusReq = useTabs((s) => s.titleFocusReq);
   useEffect(() => {
     if (!scrollTopReq || scrollTopReq.rel !== rel) return;
     savedScroll.current = 0;
@@ -359,6 +390,36 @@ export const NoteEditor = memo(function NoteEditor({
         : Promise.resolve();
     flush.then(action);
   };
+
+  useEffect(() => {
+    if (!active || !editor) return;
+    const handle = async (event: Event) => {
+      try {
+        const action = (event as CustomEvent<{ action?: string }>).detail?.action;
+        const markdown = markdownSource
+          ? rawText
+          : joinFrontmatter(frontmatter.current, editor.getMarkdown());
+
+        if (action === "copy") {
+          await navigator.clipboard.writeText(markdown);
+          toast("Markdown copied");
+        } else if (action === "export") {
+          const path = await ipc.exportNote(relRef.current, markdown);
+          if (path) toast("Note exported", { description: path });
+        } else if (action === "delete") {
+          debouncedPersist.cancel();
+          if (pending.current !== null) {
+            await persist(pending.current, relRef.current);
+          }
+          await useVault.getState().deleteEntry(relRef.current);
+        }
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : String(err));
+      }
+    };
+    window.addEventListener("markd:note-action", handle);
+    return () => window.removeEventListener("markd:note-action", handle);
+  }, [active, debouncedPersist, editor, markdownSource, persist, rawText]);
 
   // Insert a page link to `rel` over the slash range, as a link mark whose
   // href is the note path (serializes to `[title](rel)` markdown on save).
@@ -397,15 +458,42 @@ export const NoteEditor = memo(function NoteEditor({
           <TitleInput
             key={rel}
             title={noteTitle(rel)}
+            focusNonce={
+              titleFocusReq?.rel === rel ? titleFocusReq.nonce : undefined
+            }
             onRename={(name) => flushThen(() => renameEntry(rel, name))}
           />
         )}
         <div className={cx(missing && "hidden")}>
-          <NoteProperties properties={properties} />
-          <EditorContent editor={editor} />
+          {markdownSource ? (
+            <textarea
+              value={rawText}
+              aria-label="Markdown source"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              onChange={(event) => {
+                const text = event.target.value;
+                setRawText(text);
+                const { frontmatter: fm, body } = splitFrontmatter(text);
+                frontmatter.current = fm;
+                setProperties(parseFrontmatter(fm));
+                pending.current = body;
+                setSaveState("saving");
+                debouncedPersist(body);
+                setWords(countWords(body));
+              }}
+              className="min-h-[calc(100vh-190px)] w-full resize-none bg-transparent pb-20 font-mono text-[13px] leading-6 text-ink outline-none placeholder:text-faint"
+            />
+          ) : (
+            <>
+              <NoteProperties properties={properties} />
+              <EditorContent editor={editor} />
+            </>
+          )}
         </div>
-        {active && editor && <SelectionMenu editor={editor} />}
-        {active && (
+        {active && editor && !markdownSource && <SelectionMenu editor={editor} />}
+        {active && !markdownSource && (
           <SlashMenu
             editor={editor}
             menu={slashMenu}
@@ -422,7 +510,7 @@ export const NoteEditor = memo(function NoteEditor({
             }}
           />
         )}
-        {active && linkPicker && (
+        {active && !markdownSource && linkPicker && (
           <NoteLinkPicker
             state={linkPicker}
             currentRel={rel}
@@ -449,12 +537,20 @@ type EditorInstance = ReturnType<typeof useEditor>;
 
 function TitleInput({
   title,
+  focusNonce,
   onRename,
 }: {
   title: string;
+  focusNonce?: number;
   onRename: (name: string) => void;
 }) {
   const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (focusNonce === undefined) return;
+    ref.current?.focus();
+    ref.current?.select();
+  }, [focusNonce]);
 
   const submit = () => {
     const value = ref.current?.value.trim();

--- a/src/components/editor/TabBar.tsx
+++ b/src/components/editor/TabBar.tsx
@@ -25,8 +25,13 @@ export function TabBar() {
       role="tablist"
       className="flex min-w-0 flex-1 items-stretch overflow-x-auto [scrollbar-width:none]"
     >
-      {tabs.map((rel) => (
-        <Tab key={rel} rel={rel} active={rel === active} />
+      {tabs.map((rel, index) => (
+        <Tab
+          key={rel}
+          rel={rel}
+          active={rel === active}
+          focusable={rel === active || (!active && index === 0)}
+        />
       ))}
     </motion.div>
   );
@@ -44,16 +49,25 @@ export function closeTab(rel: string) {
   }
 }
 
-function Tab({ rel, active }: { rel: string; active: boolean }) {
+function Tab({
+  rel,
+  active,
+  focusable,
+}: {
+  rel: string;
+  active: boolean;
+  focusable: boolean;
+}) {
   const setView = useVault((s) => s.setView);
 
   return (
     <div
       role="tab"
       aria-selected={active}
+      tabIndex={focusable ? 0 : -1}
       title={rel}
       className={cx(
-        "group/tab relative flex h-full min-w-0 max-w-[180px] shrink-0 cursor-pointer select-none items-center gap-1 pl-3 pr-1.5 text-[12.5px] transition-colors duration-100",
+        "group/tab relative flex h-full min-w-0 max-w-[180px] shrink-0 cursor-pointer select-none items-center gap-1 pl-3 pr-1.5 text-[12.5px] transition-colors duration-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ink",
         active ? "text-ink" : "text-muted hover:text-ink",
       )}
       onClick={() => {
@@ -62,6 +76,28 @@ function Tab({ rel, active }: { rel: string; active: boolean }) {
       onAuxClick={(event) => {
         // middle-click closes, like every code editor
         if (event.button === 1) closeTab(rel);
+      }}
+      onKeyDown={(event) => {
+        const tabs = Array.from(
+          event.currentTarget.parentElement?.querySelectorAll<HTMLElement>(
+            '[role="tab"]',
+          ) ?? [],
+        );
+        const index = tabs.indexOf(event.currentTarget);
+        let next = index;
+        if (event.key === "ArrowRight") next = (index + 1) % tabs.length;
+        else if (event.key === "ArrowLeft") {
+          next = (index - 1 + tabs.length) % tabs.length;
+        } else if (event.key === "Home") next = 0;
+        else if (event.key === "End") next = tabs.length - 1;
+        else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          setView({ type: "note", rel });
+          return;
+        } else return;
+        event.preventDefault();
+        tabs[next]?.focus();
+        tabs[next]?.click();
       }}
     >
       {/* Active fill glides between tabs via shared layout; inactive rows get

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -12,6 +12,7 @@ import TaskList from "@tiptap/extension-task-list";
 import Typography from "@tiptap/extension-typography";
 import Underline from "@tiptap/extension-underline";
 import StarterKit from "@tiptap/starter-kit";
+import { CodeBlockWithCopy } from "./CodeBlock";
 import { WikiLink } from "./wikiLink";
 
 function isRemoteSource(src: string) {
@@ -59,7 +60,8 @@ export function createExtensions(vaultRoot: string) {
     Markdown.configure({
       markedOptions: { breaks: true, gfm: true },
     }),
-    StarterKit.configure({ link: false }),
+    StarterKit.configure({ link: false, codeBlock: false }),
+    CodeBlockWithCopy,
     Underline,
     Typography,
     Link.configure({

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Download, FileCode2, FilePlus, MoreHorizontal, PanelLeft, Search, Tag, Trash2, X } from "lucide-react";
+import { Check, Code2, Copy, Download, FilePlus, MoreVertical, PanelLeft, Pilcrow, Search, Tag, Trash2, X } from "lucide-react";
 import { AnimatePresence, LayoutGroup, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { NoteBreadcrumb } from "@/components/editor/NoteBreadcrumb";
@@ -8,11 +8,18 @@ import { BookmarksPage } from "@/components/bookmarks/BookmarksPage";
 import { TodosPage } from "@/components/todos/TodosPage";
 import { EASE_OUT, SPRING_LAYOUT, SPRING_PANEL } from "@/lib/ease";
 import { cx } from "@/lib/utils";
-import { ActionSwapText } from "@/components/motion/action-swap";
+import {
+  ActionSwapIcon,
+  ActionSwapText,
+} from "@/components/motion/action-swap";
+import {
+  MorphPopover,
+  MorphPopoverContent,
+  MorphPopoverTrigger,
+} from "@/components/motion/popover-morph";
 import { Sidebar } from "./Sidebar";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Tooltip } from "@/components/ui/Tooltip";
-import { ContextMenu, type MenuPosition } from "@/components/ui/ContextMenu";
 import { useBookmarks } from "@/stores/bookmarks";
 import { useTodos } from "@/stores/todos";
 import { useUi } from "@/stores/ui";
@@ -42,7 +49,7 @@ export function AppShell() {
   const createBookmarkTag = useBookmarks((s) => s.createTag);
   const exportBookmarks = useBookmarks((s) => s.exportAll);
   const createTodoTag = useTodos((s) => s.createTag);
-  const [noteMenu, setNoteMenu] = useState<MenuPosition | null>(null);
+  const [noteMenuOpen, setNoteMenuOpen] = useState(false);
 
   const path = viewPath(root, view);
 
@@ -107,40 +114,34 @@ export function AppShell() {
           <LayoutGroup>
             <div className="ml-auto flex items-center gap-2">
               {view?.type === "note" && (
-                <>
-                  <Tooltip
-                    label={markdownSource ? "Show rich editor" : "Show Markdown source"}
-                    side="bottom"
+                <Tooltip
+                  label={markdownSource ? "Show rich editor" : "Show Markdown source"}
+                  side="bottom"
+                >
+                  <button
+                    type="button"
+                    aria-pressed={markdownSource}
+                    onClick={toggleMarkdownSource}
+                    className={cx(
+                      "grid h-7 w-7 place-items-center rounded-md border transition-[color,background-color,border-color,transform] duration-100 active:scale-[0.96]",
+                      markdownSource
+                        ? "border-invert bg-invert text-invert-ink"
+                        : "border-line bg-hover text-muted hover:bg-active hover:text-ink",
+                    )}
                   >
-                    <button
-                      type="button"
-                      aria-pressed={markdownSource}
-                      onClick={toggleMarkdownSource}
-                      className={cx(
-                        "grid h-7 w-7 place-items-center rounded-md border transition-colors duration-100",
-                        markdownSource
-                          ? "border-invert bg-invert text-invert-ink"
-                          : "border-line bg-hover text-muted hover:bg-active hover:text-ink",
+                    <ActionSwapIcon
+                      value={markdownSource ? "rich" : "markdown"}
+                      animation="roll"
+                      className="h-[15px] w-[15px]"
+                    >
+                      {markdownSource ? (
+                        <Pilcrow size={15} strokeWidth={1.9} />
+                      ) : (
+                        <Code2 size={15} strokeWidth={1.9} />
                       )}
-                    >
-                      <FileCode2 size={14} strokeWidth={1.9} />
-                    </button>
-                  </Tooltip>
-                  <Tooltip label="Note actions" side="bottom">
-                    <button
-                      type="button"
-                      aria-haspopup="menu"
-                      aria-expanded={noteMenu !== null}
-                      onClick={(event) => {
-                        const rect = event.currentTarget.getBoundingClientRect();
-                        setNoteMenu({ x: rect.right, y: rect.bottom + 4 });
-                      }}
-                      className="grid h-7 w-7 place-items-center rounded-md border border-line bg-hover text-muted transition-colors duration-100 hover:bg-active hover:text-ink"
-                    >
-                      <MoreHorizontal size={15} strokeWidth={2} />
-                    </button>
-                  </Tooltip>
-                </>
+                    </ActionSwapIcon>
+                  </button>
+                </Tooltip>
               )}
               {path && (
                 <motion.div layout transition={SPRING_LAYOUT}>
@@ -169,32 +170,57 @@ export function AppShell() {
               {view?.type === "todos" && (
                 <NewTagButton onCreate={createTodoTag} />
               )}
+              {view?.type === "note" && (
+                <MorphPopover
+                  open={noteMenuOpen}
+                  onOpenChange={setNoteMenuOpen}
+                >
+                  <MorphPopoverTrigger>
+                    <button
+                      type="button"
+                      aria-label="Note actions"
+                      className="grid h-7 w-7 place-items-center rounded-md text-muted transition-colors duration-100 hover:text-ink"
+                    >
+                      <MoreVertical size={15} strokeWidth={2} />
+                    </button>
+                  </MorphPopoverTrigger>
+                  <MorphPopoverContent
+                    align="end"
+                    sideOffset={6}
+                    radius={10}
+                    className="w-48 bg-bg p-1"
+                  >
+                    <NoteMenuButton
+                      icon={Download}
+                      label="Export as Markdown"
+                      onClick={() => {
+                        setNoteMenuOpen(false);
+                        dispatchNoteAction("export");
+                      }}
+                    />
+                    <NoteMenuButton
+                      icon={Copy}
+                      label="Copy Markdown"
+                      onClick={() => {
+                        setNoteMenuOpen(false);
+                        dispatchNoteAction("copy");
+                      }}
+                    />
+                    <div className="mx-1 my-1 border-t border-line-soft" />
+                    <NoteMenuButton
+                      icon={Trash2}
+                      label="Delete note"
+                      danger
+                      onClick={() => {
+                        setNoteMenuOpen(false);
+                        dispatchNoteAction("delete");
+                      }}
+                    />
+                  </MorphPopoverContent>
+                </MorphPopover>
+              )}
             </div>
           </LayoutGroup>
-          {noteMenu && view?.type === "note" && (
-            <ContextMenu
-              position={noteMenu}
-              onClose={() => setNoteMenu(null)}
-              items={[
-                {
-                  label: "Export as Markdown",
-                  icon: Download,
-                  onSelect: () => dispatchNoteAction("export"),
-                },
-                {
-                  label: "Copy Markdown",
-                  icon: Copy,
-                  onSelect: () => dispatchNoteAction("copy"),
-                },
-                {
-                  label: "Delete note",
-                  icon: Trash2,
-                  danger: true,
-                  onSelect: () => dispatchNoteAction("delete"),
-                },
-              ]}
-            />
-          )}
         </div>
 
         <div className="relative min-h-0 flex-1">
@@ -223,6 +249,34 @@ type NoteAction = "export" | "copy" | "delete";
 function dispatchNoteAction(action: NoteAction) {
   window.dispatchEvent(
     new CustomEvent("markd:note-action", { detail: { action } }),
+  );
+}
+
+function NoteMenuButton({
+  icon: Icon,
+  label,
+  danger = false,
+  onClick,
+}: {
+  icon: typeof Download;
+  label: string;
+  danger?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cx(
+        "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-[13px] transition-colors duration-100",
+        danger
+          ? "text-danger hover:bg-danger/8"
+          : "text-ink hover:bg-hover",
+      )}
+    >
+      <Icon size={14} strokeWidth={1.75} />
+      {label}
+    </button>
   );
 }
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Check, Download, FilePlus, PanelLeft, Search, Tag, X } from "lucide-react";
+import { Check, Copy, Download, FileCode2, FilePlus, MoreHorizontal, PanelLeft, Search, Tag, Trash2, X } from "lucide-react";
 import { AnimatePresence, LayoutGroup, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { NoteBreadcrumb } from "@/components/editor/NoteBreadcrumb";
@@ -7,10 +7,12 @@ import { TabBar } from "@/components/editor/TabBar";
 import { BookmarksPage } from "@/components/bookmarks/BookmarksPage";
 import { TodosPage } from "@/components/todos/TodosPage";
 import { EASE_OUT, SPRING_LAYOUT, SPRING_PANEL } from "@/lib/ease";
+import { cx } from "@/lib/utils";
 import { ActionSwapText } from "@/components/motion/action-swap";
 import { Sidebar } from "./Sidebar";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Tooltip } from "@/components/ui/Tooltip";
+import { ContextMenu, type MenuPosition } from "@/components/ui/ContextMenu";
 import { useBookmarks } from "@/stores/bookmarks";
 import { useTodos } from "@/stores/todos";
 import { useUi } from "@/stores/ui";
@@ -34,10 +36,13 @@ export function AppShell() {
   const view = useVault((s) => s.view);
   const root = useVault((s) => s.root);
   const sidebarHidden = useUi((s) => s.sidebarHidden);
+  const markdownSource = useUi((s) => s.markdownSource);
   const toggleSidebar = useUi((s) => s.toggleSidebar);
+  const toggleMarkdownSource = useUi((s) => s.toggleMarkdownSource);
   const createBookmarkTag = useBookmarks((s) => s.createTag);
   const exportBookmarks = useBookmarks((s) => s.exportAll);
   const createTodoTag = useTodos((s) => s.createTag);
+  const [noteMenu, setNoteMenu] = useState<MenuPosition | null>(null);
 
   const path = viewPath(root, view);
 
@@ -101,6 +106,42 @@ export function AppShell() {
 
           <LayoutGroup>
             <div className="ml-auto flex items-center gap-2">
+              {view?.type === "note" && (
+                <>
+                  <Tooltip
+                    label={markdownSource ? "Show rich editor" : "Show Markdown source"}
+                    side="bottom"
+                  >
+                    <button
+                      type="button"
+                      aria-pressed={markdownSource}
+                      onClick={toggleMarkdownSource}
+                      className={cx(
+                        "grid h-7 w-7 place-items-center rounded-md border transition-colors duration-100",
+                        markdownSource
+                          ? "border-invert bg-invert text-invert-ink"
+                          : "border-line bg-hover text-muted hover:bg-active hover:text-ink",
+                      )}
+                    >
+                      <FileCode2 size={14} strokeWidth={1.9} />
+                    </button>
+                  </Tooltip>
+                  <Tooltip label="Note actions" side="bottom">
+                    <button
+                      type="button"
+                      aria-haspopup="menu"
+                      aria-expanded={noteMenu !== null}
+                      onClick={(event) => {
+                        const rect = event.currentTarget.getBoundingClientRect();
+                        setNoteMenu({ x: rect.right, y: rect.bottom + 4 });
+                      }}
+                      className="grid h-7 w-7 place-items-center rounded-md border border-line bg-hover text-muted transition-colors duration-100 hover:bg-active hover:text-ink"
+                    >
+                      <MoreHorizontal size={15} strokeWidth={2} />
+                    </button>
+                  </Tooltip>
+                </>
+              )}
               {path && (
                 <motion.div layout transition={SPRING_LAYOUT}>
                   <CopyButton
@@ -130,6 +171,30 @@ export function AppShell() {
               )}
             </div>
           </LayoutGroup>
+          {noteMenu && view?.type === "note" && (
+            <ContextMenu
+              position={noteMenu}
+              onClose={() => setNoteMenu(null)}
+              items={[
+                {
+                  label: "Export as Markdown",
+                  icon: Download,
+                  onSelect: () => dispatchNoteAction("export"),
+                },
+                {
+                  label: "Copy Markdown",
+                  icon: Copy,
+                  onSelect: () => dispatchNoteAction("copy"),
+                },
+                {
+                  label: "Delete note",
+                  icon: Trash2,
+                  danger: true,
+                  onSelect: () => dispatchNoteAction("delete"),
+                },
+              ]}
+            />
+          )}
         </div>
 
         <div className="relative min-h-0 flex-1">
@@ -150,6 +215,14 @@ export function AppShell() {
         </div>
       </main>
     </div>
+  );
+}
+
+type NoteAction = "export" | "copy" | "delete";
+
+function dispatchNoteAction(action: NoteAction) {
+  window.dispatchEvent(
+    new CustomEvent("markd:note-action", { detail: { action } }),
   );
 }
 

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -266,6 +266,7 @@ function NoteMenuButton({
   return (
     <button
       type="button"
+      role="menuitem"
       onClick={onClick}
       className={cx(
         "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-[13px] transition-colors duration-100",

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,7 +23,6 @@ export function Sidebar() {
   const createFolder = useVault((s) => s.createFolder);
   const setSettingsOpen = useUi((s) => s.setSettingsOpen);
   const setPaletteOpen = useUi((s) => s.setPaletteOpen);
-  const saveState = useUi((s) => s.saveState);
 
   return (
     <aside className="flex h-full w-[240px] shrink-0 flex-col border-r border-line-soft bg-panel">
@@ -94,20 +93,10 @@ export function Sidebar() {
 
       <UpdateRow />
 
-      <div className="flex items-center justify-between border-t border-line-soft px-2 py-1.5">
+      <div className="flex items-center border-t border-line-soft px-2 py-1.5">
         <IconAction label="Settings" onClick={() => setSettingsOpen(true)}>
           <Settings size={15} strokeWidth={1.75} />
         </IconAction>
-        <span
-          className={cx(
-            "pr-2 text-[11px] transition-opacity duration-300",
-            saveState === "idle" && "opacity-0",
-            saveState === "saving" && "text-faint opacity-100",
-            saveState === "error" && "text-danger opacity-100",
-          )}
-        >
-          {saveState === "error" ? "not saved" : "saving…"}
-        </span>
       </div>
     </aside>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -93,10 +93,18 @@ export function Sidebar() {
 
       <UpdateRow />
 
-      <div className="flex items-center border-t border-line-soft px-2 py-1.5">
-        <IconAction label="Settings" onClick={() => setSettingsOpen(true)}>
+      <div className="border-t border-line-soft px-2 py-1.5">
+        <button
+          type="button"
+          onClick={() => setSettingsOpen(true)}
+          className="flex h-[30px] w-full items-center gap-2.5 rounded-md px-2 text-[13px] font-medium text-muted transition-colors duration-100 hover:bg-hover hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-ink"
+        >
           <Settings size={15} strokeWidth={1.75} />
-        </IconAction>
+          <span>Settings</span>
+          <kbd className="ml-auto font-mono text-[10px] font-normal text-faint">
+            ⌘,
+          </kbd>
+        </button>
       </div>
     </aside>
   );

--- a/src/components/motion/popover-morph.tsx
+++ b/src/components/motion/popover-morph.tsx
@@ -1,0 +1,231 @@
+"use client";
+// beui.dev/components/motion/popover
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import {
+  cloneElement,
+  createContext,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { SPRING_PANEL } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type Side = "top" | "bottom";
+type Align = "start" | "end";
+
+type MorphContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  triggerId: string;
+  contentId: string;
+};
+
+const MorphContext = createContext<MorphContextValue | null>(null);
+
+function useMorphContext(component: string) {
+  const ctx = useContext(MorphContext);
+  if (!ctx) throw new Error(`${component} must be used within <MorphPopover>`);
+  return ctx;
+}
+
+export interface MorphPopoverProps {
+  children: ReactNode;
+  /** Controlled open state. */
+  open?: boolean;
+  /** Uncontrolled initial open state. */
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+/**
+ * A popover whose panel morphs open from the trigger corner: it's laid out at
+ * full size but clipped to the corner nearest the trigger, then unclips as one
+ * piece. Closes on outside pointer / Escape. Controlled or uncontrolled.
+ */
+export function MorphPopover({
+  children,
+  open: controlledOpen,
+  defaultOpen = false,
+  onOpenChange,
+  className,
+}: MorphPopoverProps) {
+  const baseId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const controlled = controlledOpen !== undefined;
+  const open = controlled ? controlledOpen : internalOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!controlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [controlled, onOpenChange],
+  );
+  const toggle = useCallback(() => setOpen(!open), [setOpen, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    const onPointer = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node))
+        setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("pointerdown", onPointer);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("pointerdown", onPointer);
+    };
+  }, [open, setOpen]);
+
+  const ctx = useMemo<MorphContextValue>(
+    () => ({
+      open,
+      setOpen,
+      toggle,
+      triggerId: `${baseId}-trigger`,
+      contentId: `${baseId}-content`,
+    }),
+    [open, setOpen, toggle, baseId],
+  );
+
+  return (
+    <MorphContext.Provider value={ctx}>
+      <div ref={rootRef} className={cn("relative inline-flex", className)}>
+        {children}
+      </div>
+    </MorphContext.Provider>
+  );
+}
+
+export interface MorphPopoverTriggerProps {
+  children: ReactElement;
+}
+
+/** Wraps a single element, toggling the popover on click. */
+export function MorphPopoverTrigger({ children }: MorphPopoverTriggerProps) {
+  const ctx = useMorphContext("MorphPopoverTrigger");
+  if (!isValidElement(children)) return children;
+
+  const child = children as ReactElement<Record<string, unknown>>;
+  const childOnClick = child.props.onClick as
+    | ((e: unknown) => void)
+    | undefined;
+
+  return cloneElement(child, {
+    id: ctx.triggerId,
+    onClick: (e: unknown) => {
+      childOnClick?.(e);
+      ctx.toggle();
+    },
+    "aria-haspopup": "menu",
+    "aria-expanded": ctx.open,
+    "aria-controls": ctx.open ? ctx.contentId : undefined,
+  });
+}
+
+const originFor = (side: Side, align: Align) =>
+  `${side === "bottom" ? "top" : "bottom"} ${align === "end" ? "right" : "left"}`;
+
+// A clip that hides everything but the corner nearest the trigger, so the
+// panel appears to grow out of it. inset(top right bottom left).
+function clipHidden(side: Side, align: Align, radius: number) {
+  const top = side === "bottom" ? "0%" : "92%";
+  const bottom = side === "bottom" ? "92%" : "0%";
+  const right = align === "end" ? "0%" : "92%";
+  const left = align === "end" ? "92%" : "0%";
+  return `inset(${top} ${right} ${bottom} ${left} round ${radius}px)`;
+}
+const clipShown = (radius: number) => `inset(0% 0% 0% 0% round ${radius}px)`;
+
+export interface MorphPopoverContentProps {
+  children: ReactNode;
+  side?: Side;
+  align?: Align;
+  /** Gap between trigger and panel, in px. Default 8. */
+  sideOffset?: number;
+  /** Panel corner radius, in px. Default 16. */
+  radius?: number;
+  className?: string;
+}
+
+export function MorphPopoverContent({
+  children,
+  side = "bottom",
+  align = "end",
+  sideOffset = 8,
+  radius = 16,
+  className,
+}: MorphPopoverContentProps) {
+  const ctx = useMorphContext("MorphPopoverContent");
+  const reduce = useReducedMotion() ?? false;
+
+  const posClass = cn(
+    side === "bottom" ? "top-full" : "bottom-full",
+    align === "end" ? "right-0" : "left-0",
+  );
+  const marginStyle =
+    side === "bottom" ? { marginTop: sideOffset } : { marginBottom: sideOffset };
+
+  // Close animates with the same spring as open, so it morphs back to the
+  // corner instead of snapping shut.
+  const wrap = reduce
+    ? undefined
+    : {
+        hidden: { opacity: 0, scale: 0.96 },
+        show: { opacity: 1, scale: 1, transition: SPRING_PANEL },
+        exit: { opacity: 0, scale: 0.96, transition: SPRING_PANEL },
+      };
+  const clip = reduce
+    ? undefined
+    : {
+        hidden: { clipPath: clipHidden(side, align, radius) },
+        show: { clipPath: clipShown(radius), transition: SPRING_PANEL },
+        exit: { clipPath: clipHidden(side, align, radius), transition: SPRING_PANEL },
+      };
+
+  return (
+    <AnimatePresence>
+      {ctx.open ? (
+        <motion.div
+          // Wrapper carries the shadow as a drop-shadow filter, which hugs the
+          // clipped shape below (box-shadow would just get clipped away).
+          variants={wrap}
+          initial={reduce ? { opacity: 0 } : "hidden"}
+          animate={reduce ? { opacity: 1 } : "show"}
+          exit={reduce ? { opacity: 0 } : "exit"}
+          transition={reduce ? { duration: 0.12 } : undefined}
+          style={{ transformOrigin: originFor(side, align), ...marginStyle }}
+          className={cn(
+            "absolute z-30 [filter:drop-shadow(0_10px_18px_rgba(0,0,0,0.14))]",
+            posClass,
+          )}
+        >
+          <motion.div
+            id={ctx.contentId}
+            variants={clip}
+            style={{ borderRadius: radius }}
+            className={cn(
+              "overflow-hidden border border-border bg-background",
+              className,
+            )}
+          >
+            {children}
+          </motion.div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/src/components/motion/popover-morph.tsx
+++ b/src/components/motion/popover-morph.tsx
@@ -171,6 +171,38 @@ export function MorphPopoverContent({
 }: MorphPopoverContentProps) {
   const ctx = useMorphContext("MorphPopoverContent");
   const reduce = useReducedMotion() ?? false;
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ctx.open) return;
+    requestAnimationFrame(() => {
+      contentRef.current
+        ?.querySelector<HTMLElement>('[role="menuitem"]')
+        ?.focus();
+    });
+  }, [ctx.open]);
+
+  const onMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const items = Array.from(
+      contentRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ??
+        [],
+    );
+    const index = items.indexOf(document.activeElement as HTMLElement);
+    let next = index;
+    if (event.key === "ArrowDown") next = (index + 1) % items.length;
+    else if (event.key === "ArrowUp") {
+      next = (index - 1 + items.length) % items.length;
+    } else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = items.length - 1;
+    else if (event.key === "Escape") {
+      event.preventDefault();
+      ctx.setOpen(false);
+      document.getElementById(ctx.triggerId)?.focus();
+      return;
+    } else return;
+    event.preventDefault();
+    items[next]?.focus();
+  };
 
   const posClass = cn(
     side === "bottom" ? "top-full" : "bottom-full",
@@ -214,7 +246,11 @@ export function MorphPopoverContent({
           )}
         >
           <motion.div
+            ref={contentRef}
             id={ctx.contentId}
+            role="menu"
+            aria-labelledby={ctx.triggerId}
+            onKeyDown={onMenuKeyDown}
             variants={clip}
             style={{ borderRadius: radius }}
             className={cn(

--- a/src/components/palette/CommandPalette.tsx
+++ b/src/components/palette/CommandPalette.tsx
@@ -193,6 +193,7 @@ export function CommandPalette() {
     <Modal
       open={open}
       onClose={close}
+      ariaLabel="Command palette"
       align="top"
       className="mt-[16vh] w-[560px]"
     >

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1,4 +1,12 @@
-import { FolderOpen, Monitor, Moon, RefreshCw, Sun, X } from "lucide-react";
+import {
+  FolderOpen,
+  Monitor,
+  Moon,
+  RefreshCw,
+  Settings,
+  Sun,
+  X,
+} from "lucide-react";
 import type { Theme } from "@/lib/types";
 import { cx } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
@@ -35,47 +43,68 @@ export function SettingsModal() {
   const installUpdate = useUpdater((s) => s.install);
 
   return (
-    <Modal open={open} onClose={() => setOpen(false)} className="w-[440px] p-5">
-      <div className="flex items-center justify-between">
-        <h2 className="text-[16px] font-semibold tracking-[-0.01em]">Settings</h2>
+    <Modal
+      open={open}
+      onClose={() => setOpen(false)}
+      ariaLabel="Settings"
+      className="w-[460px]"
+    >
+      <header className="flex items-center gap-3 border-b border-line-soft px-5 py-4">
+        <div className="grid h-8 w-8 place-items-center rounded-lg bg-invert text-invert-ink">
+          <Settings size={15} strokeWidth={1.8} />
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-[15px] font-semibold tracking-[-0.01em]">
+            Settings
+          </h2>
+          <p className="mt-0.5 text-[11.5px] text-faint">
+            Appearance, vault, updates, and shortcuts
+          </p>
+        </div>
         <button
           type="button"
           aria-label="Close settings"
           onClick={() => setOpen(false)}
-          className="grid h-7 w-7 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink"
+          className="ml-auto grid h-8 w-8 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink"
         >
           <X size={15} strokeWidth={2} />
         </button>
-      </div>
+      </header>
 
-      <section className="mt-5">
-        <div className="flex items-center justify-between">
-          <Label>Appearance</Label>
-          <span className="text-[11px] text-faint">
-            <Kbd>⌘</Kbd>
-            <Kbd>⇧</Kbd>
-            <Kbd>D</Kbd> to cycle
-          </span>
-        </div>
-        <div className="mt-2 grid grid-cols-3 gap-1 rounded-xl bg-panel p-1">
-          {THEMES.map(({ value, label, icon: Icon }) => (
-            <button
-              key={value}
-              type="button"
-              className={cx(
-                "flex flex-col items-center gap-1.5 rounded-lg py-2.5 text-[12.5px] font-medium transition-colors duration-100",
-                theme === value
-                  ? "bg-invert text-invert-ink"
-                  : "text-muted hover:bg-hover hover:text-ink",
-              )}
-              onClick={() => setTheme(value)}
-            >
-              <Icon size={16} strokeWidth={1.75} />
-              {label}
-            </button>
-          ))}
-        </div>
-      </section>
+      <div className="page-scroll max-h-[min(620px,calc(100vh-96px))] px-5 pb-5">
+        <section className="pt-5">
+          <div className="flex items-center justify-between">
+            <Label>Appearance</Label>
+            <span className="text-[11px] text-faint">
+              <Kbd>⌘</Kbd>
+              <Kbd>⇧</Kbd>
+              <Kbd>D</Kbd> to cycle
+            </span>
+          </div>
+          <div
+            role="group"
+            aria-label="Theme"
+            className="mt-2 grid grid-cols-3 gap-1 rounded-xl bg-panel p-1"
+          >
+            {THEMES.map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={theme === value}
+                className={cx(
+                  "flex flex-col items-center gap-1.5 rounded-lg py-2.5 text-[12.5px] font-medium transition-colors duration-100",
+                  theme === value
+                    ? "bg-invert text-invert-ink"
+                    : "text-muted hover:bg-hover hover:text-ink",
+                )}
+                onClick={() => setTheme(value)}
+              >
+                <Icon size={16} strokeWidth={1.75} />
+                {label}
+              </button>
+            ))}
+          </div>
+        </section>
 
       <section className="mt-5">
         <Label>Vault</Label>
@@ -96,7 +125,10 @@ export function SettingsModal() {
       <section className="mt-5">
         <Label>Updates</Label>
         <div className="mt-2 flex items-center justify-between gap-2">
-          <p className="min-w-0 truncate text-[12.5px] text-muted">
+          <p
+            aria-live="polite"
+            className="min-w-0 truncate text-[12.5px] text-muted"
+          >
             {updateStatus === "available"
               ? `Version ${updateVersion} is available`
               : updateStatus === "downloading" || updateStatus === "ready"
@@ -146,9 +178,10 @@ export function SettingsModal() {
         </div>
       </section>
 
-      <p className="mt-6 text-center text-[11px] text-faint">
-        Markd · notes as plain markdown, on your disk
-      </p>
+        <p className="mt-6 text-center text-[11px] text-faint">
+          Markd · notes as plain markdown, on your disk
+        </p>
+      </div>
     </Modal>
   );
 }

--- a/src/components/tree/FileTree.tsx
+++ b/src/components/tree/FileTree.tsx
@@ -52,6 +52,8 @@ const treeCollisionDetection: CollisionDetection = (args) => {
 interface TreeApi {
   renaming: string | null;
   setRenaming: (rel: string | null) => void;
+  focusRel: string | null;
+  setFocusRel: (rel: string) => void;
   dragging: string | null;
   openMenu: (position: MenuPosition, node: TreeNode) => void;
 }
@@ -62,6 +64,7 @@ export function FileTree() {
   const tree = useVault((s) => s.tree);
   const moveEntry = useVault((s) => s.moveEntry);
   const [renaming, setRenaming] = useState<string | null>(null);
+  const [focusRel, setFocusRel] = useState<string | null>(null);
   const [dragging, setDragging] = useState<string | null>(null);
   const [menu, setMenu] = useState<{
     position: MenuPosition;
@@ -88,6 +91,13 @@ export function FileTree() {
   };
   const draggedNode = dragging ? findNode(tree, dragging) : null;
 
+  useEffect(() => {
+    const currentView = useVault.getState().view;
+    const activeRel = currentView?.type === "note" ? currentView.rel : null;
+    if (focusRel && findNode(tree, focusRel)) return;
+    setFocusRel(activeRel && findNode(tree, activeRel) ? activeRel : tree[0]?.rel ?? null);
+  }, [tree, focusRel]);
+
   return (
     <DndContext
       sensors={sensors}
@@ -97,7 +107,14 @@ export function FileTree() {
       onDragEnd={finishDrag}
     >
       <TreeContext.Provider
-        value={{ renaming, setRenaming, dragging, openMenu }}
+        value={{
+          renaming,
+          setRenaming,
+          focusRel,
+          setFocusRel,
+          dragging,
+          openMenu,
+        }}
       >
         <TreeList tree={tree} dragging={dragging} />
         {menu && (
@@ -193,6 +210,8 @@ function TreeList({
   return (
     <div
       ref={setNodeRef}
+      role="tree"
+      aria-label="Notes"
       className="no-scrollbar relative min-h-0 flex-1 overflow-y-auto px-2 pb-6 pt-1"
     >
       {tree.map((node) => (
@@ -254,6 +273,8 @@ function Row({ node, depth }: { node: TreeNode; depth: number }) {
         {...listeners}
         role="treeitem"
         aria-selected={isActive}
+        aria-expanded={isFolder ? isOpen : undefined}
+        tabIndex={api?.focusRel === node.rel ? 0 : -1}
         className={cx(
           "group relative flex h-[30px] touch-none cursor-pointer items-center rounded-md pr-1.5 text-[13px] transition-colors duration-100",
           isActive
@@ -266,6 +287,7 @@ function Row({ node, depth }: { node: TreeNode; depth: number }) {
           paddingLeft: 8 + depth * 15,
         }}
         onClick={() => {
+          api?.setFocusRel(node.rel);
           if (isFolder) {
             toggleExpanded(node.rel);
           } else {
@@ -277,6 +299,54 @@ function Row({ node, depth }: { node: TreeNode; depth: number }) {
           event.stopPropagation();
           api?.openMenu({ x: event.clientX, y: event.clientY }, node);
         }}
+        onFocus={() => api?.setFocusRel(node.rel)}
+        onKeyDown={(event) => {
+          if (isRenaming) return;
+          const treeRoot = event.currentTarget.closest('[role="tree"]');
+          const items = Array.from(
+            treeRoot?.querySelectorAll<HTMLElement>('[role="treeitem"]') ?? [],
+          );
+          const index = items.indexOf(event.currentTarget);
+          const focusAt = (next: number) => {
+            const item = items[next];
+            if (!item) return;
+            event.preventDefault();
+            item.focus();
+          };
+
+          if (event.key === "ArrowDown") {
+            focusAt(Math.min(index + 1, items.length - 1));
+          } else if (event.key === "ArrowUp") {
+            focusAt(Math.max(index - 1, 0));
+          } else if (event.key === "Home") {
+            focusAt(0);
+          } else if (event.key === "End") {
+            focusAt(items.length - 1);
+          } else if (event.key === "ArrowRight" && isFolder) {
+            event.preventDefault();
+            if (!isOpen) toggleExpanded(node.rel);
+            else focusAt(index + 1);
+          } else if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            if (isFolder && isOpen) {
+              toggleExpanded(node.rel);
+            } else {
+              const parent = parentDir(node.rel);
+              const parentItem = items.find(
+                (item) => item.dataset.rel === parent,
+              );
+              parentItem?.focus();
+            }
+          } else if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            if (isFolder) toggleExpanded(node.rel);
+            else setView({ type: "note", rel: node.rel });
+          } else if (event.key === "F2") {
+            event.preventDefault();
+            api?.setRenaming(node.rel);
+          }
+        }}
+        data-rel={node.rel}
       >
         {isFolder ? (
           <ActionSwapIcon

--- a/src/components/tree/FileTree.tsx
+++ b/src/components/tree/FileTree.tsx
@@ -1,4 +1,16 @@
 import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
   FilePlus,
   FileText,
   Folder,
@@ -27,11 +39,20 @@ import {
 } from "@/components/ui/ContextMenu";
 import { ActionSwapIcon } from "@/components/motion/action-swap";
 
-const DRAG_TYPE = "application/x-markd-rel";
+const ROOT_DROP_ID = "markd:notes-root";
+
+const treeCollisionDetection: CollisionDetection = (args) => {
+  const collisions = pointerWithin(args);
+  const folderCollisions = collisions.filter(
+    (collision) => collision.id !== ROOT_DROP_ID,
+  );
+  return folderCollisions.length > 0 ? folderCollisions : collisions;
+};
 
 interface TreeApi {
   renaming: string | null;
   setRenaming: (rel: string | null) => void;
+  dragging: string | null;
   openMenu: (position: MenuPosition, node: TreeNode) => void;
 }
 
@@ -41,60 +62,56 @@ export function FileTree() {
   const tree = useVault((s) => s.tree);
   const moveEntry = useVault((s) => s.moveEntry);
   const [renaming, setRenaming] = useState<string | null>(null);
+  const [dragging, setDragging] = useState<string | null>(null);
   const [menu, setMenu] = useState<{
     position: MenuPosition;
     node: TreeNode;
   } | null>(null);
-  const [rootDropping, setRootDropping] = useState(false);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
 
   const openMenu = useCallback(
     (position: MenuPosition, node: TreeNode) => setMenu({ position, node }),
     [],
   );
 
+  const finishDrag = ({ active, over }: DragEndEvent) => {
+    setDragging(null);
+    if (!over) return;
+    const rel = String(active.id);
+    const dir = String(over.data.current?.dir ?? "");
+    if (rel === dir || dir.startsWith(`${rel}/`) || parentDir(rel) === dir) {
+      return;
+    }
+    moveEntry(rel, dir);
+  };
+  const draggedNode = dragging ? findNode(tree, dragging) : null;
+
   return (
-    <TreeContext.Provider value={{ renaming, setRenaming, openMenu }}>
-      <div
-        className={cx(
-          "no-scrollbar min-h-0 flex-1 overflow-y-auto px-2 pb-6 pt-1",
-          rootDropping && "bg-hover",
-        )}
-        onDragOver={(event) => {
-          if (event.dataTransfer.types.includes(DRAG_TYPE)) {
-            event.preventDefault();
-            setRootDropping(true);
-          }
-        }}
-        onDragLeave={(event) => {
-          if (event.currentTarget === event.target) setRootDropping(false);
-        }}
-        onDrop={(event) => {
-          setRootDropping(false);
-          const rel = event.dataTransfer.getData(DRAG_TYPE);
-          if (rel && parentDir(rel) !== "") moveEntry(rel, "");
-        }}
+    <DndContext
+      sensors={sensors}
+      collisionDetection={treeCollisionDetection}
+      onDragStart={({ active }) => setDragging(String(active.id))}
+      onDragCancel={() => setDragging(null)}
+      onDragEnd={finishDrag}
+    >
+      <TreeContext.Provider
+        value={{ renaming, setRenaming, dragging, openMenu }}
       >
-        {tree.map((node) => (
-          <Row key={node.rel} node={node} depth={0} />
-        ))}
-        {tree.length === 0 && (
-          <p className="px-2 pt-2 text-[12.5px] leading-relaxed text-faint">
-            No notes yet. Press{" "}
-            <kbd className="rounded border border-line bg-bg px-1 font-mono text-[10.5px]">
-              ⌘N
-            </kbd>{" "}
-            to create one.
-          </p>
+        <TreeList tree={tree} dragging={dragging} />
+        {menu && (
+          <ContextMenu
+            position={menu.position}
+            items={menuItems(menu.node)}
+            onClose={() => setMenu(null)}
+          />
         )}
-      </div>
-      {menu && (
-        <ContextMenu
-          position={menu.position}
-          items={menuItems(menu.node)}
-          onClose={() => setMenu(null)}
-        />
-      )}
-    </TreeContext.Provider>
+        <DragOverlay dropAnimation={null}>
+          {draggedNode ? <DragPreview node={draggedNode} /> : null}
+        </DragOverlay>
+      </TreeContext.Provider>
+    </DndContext>
   );
 
   function menuItems(node: TreeNode): MenuItem[] {
@@ -134,34 +151,120 @@ export function FileTree() {
   }
 }
 
+function findNode(nodes: TreeNode[], rel: string): TreeNode | null {
+  for (const node of nodes) {
+    if (node.rel === rel) return node;
+    const child = node.children ? findNode(node.children, rel) : null;
+    if (child) return child;
+  }
+  return null;
+}
+
+function DragPreview({ node }: { node: TreeNode }) {
+  const isFolder = node.kind === "folder";
+  return (
+    <div className="flex h-[30px] w-[208px] items-center rounded-md border border-line bg-panel px-2 text-[13px] text-ink shadow-lg shadow-black/10">
+      {isFolder ? (
+        <Folder size={14} strokeWidth={1.75} className="mr-2 text-faint" />
+      ) : (
+        <FileText size={14} strokeWidth={1.75} className="mr-2 text-faint" />
+      )}
+      <span className={cx("truncate", isFolder && "font-medium")}>
+        {node.name}
+      </span>
+    </div>
+  );
+}
+
+function TreeList({
+  tree,
+  dragging,
+}: {
+  tree: TreeNode[];
+  dragging: string | null;
+}) {
+  const eligible = Boolean(dragging && parentDir(dragging) !== "");
+  const { setNodeRef } = useDroppable({
+    id: ROOT_DROP_ID,
+    disabled: !eligible,
+    data: { dir: "" },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className="no-scrollbar relative min-h-0 flex-1 overflow-y-auto px-2 pb-6 pt-1"
+    >
+      {tree.map((node) => (
+        <Row key={node.rel} node={node} depth={0} />
+      ))}
+      {tree.length === 0 && (
+        <p className="px-2 pt-2 text-[12.5px] leading-relaxed text-faint">
+          No notes yet. Press{" "}
+          <kbd className="rounded border border-line bg-bg px-1 font-mono text-[10.5px]">
+            ⌘N
+          </kbd>{" "}
+          to create one.
+        </p>
+      )}
+    </div>
+  );
+}
+
 function Row({ node, depth }: { node: TreeNode; depth: number }) {
   const api = useContext(TreeContext);
   const view = useVault((s) => s.view);
   const expanded = useVault((s) => s.expanded);
   const toggleExpanded = useVault((s) => s.toggleExpanded);
   const setView = useVault((s) => s.setView);
-  const moveEntry = useVault((s) => s.moveEntry);
-  const [dropping, setDropping] = useState(false);
 
   const isFolder = node.kind === "folder";
   const isOpen = expanded.has(node.rel);
   const isActive = view?.type === "note" && view.rel === node.rel;
   const isRenaming = api?.renaming === node.rel;
+  const targetDir = isFolder ? node.rel : parentDir(node.rel);
+  const invalidTarget = Boolean(
+    api?.dragging &&
+      (targetDir === api.dragging || targetDir.startsWith(`${api.dragging}/`)),
+  );
+  const {
+    attributes,
+    listeners,
+    setNodeRef: setDragRef,
+    isDragging,
+  } = useDraggable({ id: node.rel, disabled: isRenaming });
+  const { isOver, setNodeRef: setDropRef } = useDroppable({
+    id: `drop:${node.rel}`,
+    disabled: invalidTarget,
+    data: { dir: targetDir },
+  });
+  const setRowRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      setDragRef(element);
+      setDropRef(element);
+    },
+    [setDragRef, setDropRef],
+  );
 
   return (
     <>
       <div
+        ref={setRowRef}
+        {...attributes}
+        {...listeners}
         role="treeitem"
         aria-selected={isActive}
-        draggable={!isRenaming}
         className={cx(
-          "group relative flex h-[30px] cursor-pointer items-center rounded-md pr-1.5 text-[13px] transition-colors duration-100",
+          "group relative flex h-[30px] touch-none cursor-pointer items-center rounded-md pr-1.5 text-[13px] transition-colors duration-100",
           isActive
             ? "bg-active text-ink"
             : "text-muted hover:bg-hover hover:text-ink",
-          dropping && !isActive && "bg-active text-ink",
+          isOver && !isActive && "bg-active text-ink",
+          isDragging && "opacity-40",
         )}
-        style={{ paddingLeft: 8 + depth * 15 }}
+        style={{
+          paddingLeft: 8 + depth * 15,
+        }}
         onClick={() => {
           if (isFolder) {
             toggleExpanded(node.rel);
@@ -173,26 +276,6 @@ function Row({ node, depth }: { node: TreeNode; depth: number }) {
           event.preventDefault();
           event.stopPropagation();
           api?.openMenu({ x: event.clientX, y: event.clientY }, node);
-        }}
-        onDragStart={(event) => {
-          event.dataTransfer.setData(DRAG_TYPE, node.rel);
-          event.dataTransfer.effectAllowed = "move";
-        }}
-        onDragOver={(event) => {
-          if (!isFolder) return;
-          if (event.dataTransfer.types.includes(DRAG_TYPE)) {
-            event.preventDefault();
-            event.stopPropagation();
-            setDropping(true);
-          }
-        }}
-        onDragLeave={() => setDropping(false)}
-        onDrop={(event) => {
-          if (!isFolder) return;
-          event.stopPropagation();
-          setDropping(false);
-          const rel = event.dataTransfer.getData(DRAG_TYPE);
-          if (rel && rel !== node.rel) moveEntry(rel, node.rel);
         }}
       >
         {isFolder ? (

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -38,11 +38,30 @@ export function ContextMenu({
   }, [position]);
 
   useEffect(() => {
+    requestAnimationFrame(() => {
+      ref.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+    });
     const close = (event: MouseEvent) => {
       if (!ref.current?.contains(event.target as Node)) onClose();
     };
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      const items = Array.from(
+        ref.current?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? [],
+      );
+      const index = items.indexOf(document.activeElement as HTMLElement);
+      let next = index;
+      if (event.key === "ArrowDown") next = (index + 1) % items.length;
+      else if (event.key === "ArrowUp") {
+        next = (index - 1 + items.length) % items.length;
+      } else if (event.key === "Home") next = 0;
+      else if (event.key === "End") next = items.length - 1;
+      else return;
+      event.preventDefault();
+      items[next]?.focus();
     };
     window.addEventListener("mousedown", close);
     window.addEventListener("contextmenu", close);
@@ -57,6 +76,7 @@ export function ContextMenu({
   return createPortal(
     <div
       ref={ref}
+      role="menu"
       className="fixed z-100 min-w-[168px] rounded-lg border border-line bg-bg p-1 shadow-lg shadow-black/8 dark:shadow-black/40"
       style={{ left: adjusted.x, top: adjusted.y }}
     >
@@ -64,6 +84,7 @@ export function ContextMenu({
         <button
           key={item.label}
           type="button"
+          role="menuitem"
           className={cx(
             "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] transition-colors duration-100",
             item.danger

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { EASE_OUT, SPRING_PANEL } from "@/lib/ease";
 import { cn } from "@/lib/utils";
@@ -19,6 +19,7 @@ export function Modal({
   align = "center",
   className,
   layoutId,
+  ariaLabel,
 }: {
   open: boolean;
   onClose: () => void;
@@ -26,18 +27,55 @@ export function Modal({
   align?: Align;
   className?: string;
   layoutId?: string;
+  ariaLabel?: string;
 }) {
   const reduce = useReducedMotion();
   const enterY = reduce ? 0 : align === "top" ? -10 : 10;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     if (!open) return;
+    previousFocus.current = document.activeElement as HTMLElement | null;
+    const focusable = () =>
+      Array.from(
+        panelRef.current?.querySelectorAll<HTMLElement>(
+          'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+    requestAnimationFrame(() => focusable()[0]?.focus());
+
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const items = focusable();
+      if (items.length === 0) {
+        event.preventDefault();
+        panelRef.current?.focus();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      previousFocus.current?.focus();
+    };
+  }, [open]);
 
   return createPortal(
     <AnimatePresence>
@@ -54,6 +92,11 @@ export function Modal({
           onMouseDown={onClose}
         >
           <motion.div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label={ariaLabel}
+            tabIndex={-1}
             layoutId={layoutId}
             initial={{ opacity: 0, y: enterY, scale: reduce ? 1 : 0.96 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}

--- a/src/components/ui/TagRail.tsx
+++ b/src/components/ui/TagRail.tsx
@@ -122,7 +122,11 @@ export function TagRail({
         </p>
       )}
 
-      <Modal open={confirmTag !== null} onClose={() => setConfirmTag(null)}>
+      <Modal
+        open={confirmTag !== null}
+        onClose={() => setConfirmTag(null)}
+        ariaLabel="Delete tag"
+      >
         <div className="w-[320px] p-5">
           <h2 className="text-[14px] font-semibold text-ink">
             Delete #{confirmTag}?

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -81,6 +81,8 @@ export const ipc = {
   bookmarkDelete: (id: string) => call<void>("bookmark_delete", { id }),
   bookmarkFetchMeta: (id: string) => call<Bookmark>("bookmark_fetch_meta", { id }),
   exportBookmarks: () => call<string | null>("export_bookmarks"),
+  exportNote: (rel: string, content: string) =>
+    call<string | null>("export_note", { rel, content }),
 
   saveImageAsset: (data: string, extension: string) =>
     call<string>("save_image_asset", { data, extension }),

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -9,6 +9,8 @@ interface TabsState {
   tabs: string[];
   /** Bumped to ask a note's pane to scroll to top (e.g. opened via a link). */
   scrollTopReq: { rel: string; nonce: number } | null;
+  /** Bumped to ask a newly created note to select its title. */
+  titleFocusReq: { rel: string; nonce: number } | null;
   /** Add a tab for `rel` if not already open (no-op otherwise). */
   open: (rel: string) => void;
   close: (rel: string) => void;
@@ -18,12 +20,15 @@ interface TabsState {
   removeUnder: (rel: string) => void;
   /** Request that `rel`'s pane jump to the top on next render. */
   requestScrollTop: (rel: string) => void;
+  /** Request that `rel`'s title input receive focus and select its text. */
+  requestTitleFocus: (rel: string) => void;
   clear: () => void;
 }
 
 export const useTabs = create<TabsState>((set, get) => ({
   tabs: [],
   scrollTopReq: null,
+  titleFocusReq: null,
 
   open: (rel) => {
     if (!get().tabs.includes(rel)) set({ tabs: [...get().tabs, rel] });
@@ -48,7 +53,15 @@ export const useTabs = create<TabsState>((set, get) => ({
       scrollTopReq: { rel, nonce: (get().scrollTopReq?.nonce ?? 0) + 1 },
     }),
 
-  clear: () => set({ tabs: [], scrollTopReq: null }),
+  requestTitleFocus: (rel) =>
+    set({
+      titleFocusReq: {
+        rel,
+        nonce: (get().titleFocusReq?.nonce ?? 0) + 1,
+      },
+    }),
+
+  clear: () => set({ tabs: [], scrollTopReq: null, titleFocusReq: null }),
 }));
 
 /** Tab to activate after closing `rel`: right neighbor, else left, else none. */

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -6,10 +6,12 @@ interface UiState {
   paletteOpen: boolean;
   settingsOpen: boolean;
   sidebarHidden: boolean;
+  markdownSource: boolean;
   saveState: SaveState;
   setPaletteOpen: (open: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
   toggleSidebar: () => void;
+  toggleMarkdownSource: () => void;
   setSaveState: (state: SaveState) => void;
 }
 
@@ -17,9 +19,12 @@ export const useUi = create<UiState>((set, get) => ({
   paletteOpen: false,
   settingsOpen: false,
   sidebarHidden: false,
+  markdownSource: false,
   saveState: "idle",
   setPaletteOpen: (paletteOpen) => set({ paletteOpen }),
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
   toggleSidebar: () => set({ sidebarHidden: !get().sidebarHidden }),
+  toggleMarkdownSource: () =>
+    set({ markdownSource: !get().markdownSource }),
   setSaveState: (saveState) => set({ saveState }),
 }));

--- a/src/stores/vault.ts
+++ b/src/stores/vault.ts
@@ -208,6 +208,7 @@ export const useVault = create<VaultState>((set, get) => ({
       get().expandTo(rel);
       // Route through setView so the tab opens (blank pane otherwise).
       get().setView({ type: "note", rel });
+      useTabs.getState().requestTitleFocus(rel);
     } catch (err) {
       oops(err);
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -205,24 +205,29 @@ body {
 .prose-note h2,
 .prose-note h3,
 .prose-note h4 {
-    font-weight: 650;
-    letter-spacing: -0.015em;
     line-height: 1.25;
 }
 .prose-note h1 {
-    font-size: 1.9em;
-    margin: 1em 0 0.4em;
+    font-size: 1.6em;
+    font-weight: 620;
+    letter-spacing: -0.018em;
+    margin: 1.15em 0 0.4em;
 }
 .prose-note h2 {
-    font-size: 1.45em;
+    font-size: 1.3em;
+    font-weight: 580;
+    letter-spacing: -0.012em;
     margin: 1.1em 0 0.35em;
 }
 .prose-note h3 {
-    font-size: 1.18em;
+    font-size: 1.1em;
+    font-weight: 560;
+    letter-spacing: -0.006em;
     margin: 1.1em 0 0.3em;
 }
 .prose-note h4 {
     font-size: 1em;
+    font-weight: 550;
     margin: 1em 0 0.25em;
 }
 
@@ -257,14 +262,19 @@ body {
     padding: 0.15em 0.4em;
 }
 
+.prose-note .code-block-wrap {
+    position: relative;
+    margin: 1em 0;
+}
+
 .prose-note pre {
     font-family: var(--font-mono);
     font-size: 0.86em;
     background: var(--panel);
     border: 1px solid var(--line-soft);
     border-radius: 8px;
-    padding: 14px 16px;
-    margin: 1em 0;
+    padding: 14px 52px 14px 16px;
+    margin: 0;
     overflow-x: auto;
 }
 .prose-note pre code {
@@ -272,6 +282,42 @@ body {
     padding: 0;
     border-radius: 0;
     font-size: 1em;
+}
+
+.prose-note .code-block-copy {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: inline-flex;
+    height: 26px;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--bg);
+    padding: 0 8px;
+    color: var(--faint);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    font-weight: 550;
+    opacity: 0;
+    transform: translateY(-2px);
+    transition:
+        opacity 120ms var(--ease-out),
+        transform 120ms var(--ease-out),
+        color 100ms ease,
+        background-color 100ms ease;
+}
+
+.prose-note .code-block-wrap:hover .code-block-copy,
+.prose-note .code-block-copy:focus-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.prose-note .code-block-copy:hover {
+    background: var(--hover);
+    color: var(--ink);
 }
 
 .prose-note hr {

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,10 @@
         text-decoration: none;
         cursor: pointer;
     }
+    :where(button, a, input, textarea, select, [tabindex]):focus-visible {
+        outline: 2px solid var(--ink);
+        outline-offset: 2px;
+    }
 }
 
 @theme inline {


### PR DESCRIPTION
## Summary

- add editable CodeMirror Markdown source mode and live note actions
- add code-block copy controls and refine editor heading typography
- replace native tree dragging with nested dnd-kit folder and root moves
- improve keyboard navigation, modal focus handling, and menu accessibility
- refresh the Settings entry and modal while documenting the Markd brand system

## Validation

- `bun run build`
- `bunx tsc --noEmit`
- `cargo test` (28 passed)
- `git diff --check`