### PR TITLE
feat: add backlinks and linked mentions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: starc007

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Tests and typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run frontend tests
+        run: bun test
+
+      - name: Run TypeScript checks
+        run: bunx tsc --noEmit
+
+      - name: Run Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml --locked

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "Markd"
 version = "0.1.4"
 dependencies = [
+ "regex",
  "reqwest",
  "scraper",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "2"
 reqwest = { version = "0.12", default-features = false, features = ["native-tls", "gzip"] }
 scraper = "0.23"
 trash = "5"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/backlink_links.rs
+++ b/src-tauri/src/backlink_links.rs
@@ -1,0 +1,243 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+fn link_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"!?\[[^\]\r\n]*\]\((?P<dest><[^>\r\n]+>|[^\s)\r\n]+)(?:[ \t]+(?:\"[^\"]*\"|'[^']*'|\([^\)]*\)))?\)"#,
+        )
+        .expect("valid Markdown link regex")
+    })
+}
+
+fn wiki_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\[\[([^\[\]|]+)(?:\|([^\[\]]+))?\]\]")
+            .expect("valid wiki link regex")
+    })
+}
+
+pub(crate) fn scan_content(
+    content: &str,
+    mut visit: impl FnMut(&str, usize, &str, bool),
+) {
+    let mut in_frontmatter = has_frontmatter(content);
+    let mut frontmatter_started = false;
+    let mut fence: Option<char> = None;
+    for (index, line) in content.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if in_frontmatter {
+            if frontmatter_started && trimmed.trim_end() == "---" {
+                in_frontmatter = false;
+            }
+            frontmatter_started = true;
+            continue;
+        }
+        if let Some(marker) = fence_marker(trimmed) {
+            if fence == Some(marker) {
+                fence = None;
+            } else if fence.is_none() {
+                fence = Some(marker);
+            }
+            continue;
+        }
+        if fence.is_some() {
+            continue;
+        }
+        let mut targets = Vec::new();
+        for capture in link_re().captures_iter(line) {
+            if !capture
+                .get(0)
+                .is_some_and(|value| value.as_str().starts_with('!'))
+            {
+                if let Some(dest) = capture.name("dest") {
+                    targets.push((dest.start(), dest.as_str(), false));
+                }
+            }
+        }
+        for capture in wiki_re().captures_iter(line) {
+            if let Some(target) = capture.get(1) {
+                targets.push((target.start(), target.as_str(), true));
+            }
+        }
+        targets.sort_by_key(|(position, _, _)| *position);
+        for (_, target, wiki) in targets {
+            visit(line, index + 1, target, wiki);
+        }
+    }
+}
+
+pub(crate) fn has_frontmatter(content: &str) -> bool {
+    let mut lines = content.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return false;
+    }
+    lines.any(|line| line.trim() == "---")
+}
+
+pub(crate) fn fence_marker(line: &str) -> Option<char> {
+    if line.starts_with("```") {
+        Some('`')
+    } else if line.starts_with("~~~") {
+        Some('~')
+    } else {
+        None
+    }
+}
+
+pub(crate) fn resolve_wiki(raw: &str, note_rels: &[String]) -> Option<String> {
+    let clean = raw.trim().trim_end_matches(".md");
+    if clean.is_empty() {
+        return None;
+    }
+    let full = format!("{clean}.md").replace('\\', "/");
+    if let Some(found) = note_rels
+        .iter()
+        .find(|rel| rel.eq_ignore_ascii_case(&full))
+    {
+        return Some(found.clone());
+    }
+    let needle = clean.rsplit('/').next()?.to_lowercase();
+    note_rels
+        .iter()
+        .find(|rel| {
+            rel.rsplit('/')
+                .next()
+                .unwrap_or(rel)
+                .trim_end_matches(".md")
+                .to_lowercase()
+                == needle
+        })
+        .cloned()
+        .or(Some(full))
+}
+
+pub(crate) fn normalize_destination(raw: &str) -> Option<String> {
+    let raw = raw.trim().trim_start_matches('<').trim_end_matches('>');
+    if raw.is_empty() || raw.starts_with('#') || raw.starts_with("//") {
+        return None;
+    }
+    let path_end = raw.find(['?', '#']).unwrap_or(raw.len());
+    let mut path = percent_decode(&raw[..path_end]).replace('\\', "/");
+    if path
+        .split('/')
+        .next()
+        .is_some_and(|first| first.contains(':'))
+    {
+        return None;
+    }
+    while path.starts_with("./") {
+        path = path[2..].to_string();
+    }
+    path = path.trim_start_matches('/').to_string();
+    if path.is_empty() || path.split('/').any(|part| part == "..") {
+        return None;
+    }
+    if !path.to_lowercase().ends_with(".md") {
+        path.push_str(".md");
+    }
+    Some(path)
+}
+
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let (Some(high), Some(low)) = (hex(bytes[index + 1]), hex(bytes[index + 2])) {
+                output.push((high << 4) | low);
+                index += 3;
+                continue;
+            }
+        }
+        output.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&output).to_string()
+}
+
+fn hex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn encode_rel(value: &str) -> String {
+    let mut output = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~' | b'/') {
+            output.push(byte as char);
+        } else {
+            output.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    output
+}
+
+pub(crate) fn rewrite_line(line: &str, from: &str, to: &str) -> String {
+    let mut replacements = Vec::new();
+    for capture in link_re().captures_iter(line) {
+        let Some(dest) = capture.name("dest") else {
+            continue;
+        };
+        let Some(normalized) = normalize_destination(dest.as_str()) else {
+            continue;
+        };
+        let mapped = if normalized == from {
+            Some(to.to_string())
+        } else {
+            normalized
+                .strip_prefix(&format!("{from}/"))
+                .map(|suffix| format!("{to}/{suffix}"))
+        };
+        if let Some(mapped) = mapped {
+            let raw = dest.as_str().trim_matches(['<', '>']);
+            let suffix_at = raw.find(['?', '#']).unwrap_or(raw.len());
+            let replacement = format!("{}{}", encode_rel(&mapped), &raw[suffix_at..]);
+            replacements.push((dest.start(), dest.end(), replacement));
+        }
+    }
+    let mut output = line.to_string();
+    for (start, end, replacement) in replacements.into_iter().rev() {
+        output.replace_range(start..end, &replacement);
+    }
+    output
+}
+
+pub(crate) fn clean_context(line: &str) -> String {
+    let without_links = link_re().replace_all(line, |capture: &regex::Captures<'_>| {
+        capture
+            .get(0)
+            .and_then(|value| value.as_str().split_once("](").map(|(label, _)| label))
+            .map(|label| label.trim_start_matches('['))
+            .unwrap_or("")
+            .to_string()
+    });
+    let without_wiki = wiki_re().replace_all(&without_links, |capture: &regex::Captures<'_>| {
+        capture
+            .get(2)
+            .or_else(|| capture.get(1))
+            .map(|value| value.as_str())
+            .unwrap_or("")
+            .to_string()
+    });
+    let clean = without_wiki
+        .trim()
+        .trim_start_matches('#')
+        .trim_start_matches(['-', '*', '+', '>'])
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if clean.chars().count() <= 220 {
+        clean
+    } else {
+        format!("{}…", clean.chars().take(219).collect::<String>())
+    }
+}

--- a/src-tauri/src/backlinks.rs
+++ b/src-tauri/src/backlinks.rs
@@ -1,0 +1,153 @@
+use std::fs;
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::backlink_links::{
+    clean_context, fence_marker, has_frontmatter, normalize_destination, resolve_wiki,
+    rewrite_line, scan_content,
+};
+use crate::error::AppResult;
+use crate::vault::{notes_root, rel_of, scan_tree, NodeKind, TreeNode};
+
+#[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BacklinkMention {
+    pub source_rel: String,
+    pub context: String,
+    pub line: usize,
+    pub occurrence: usize,
+}
+
+pub fn find_backlinks(root: &Path, target_rel: &str) -> AppResult<Vec<BacklinkMention>> {
+    let Some(target) = normalize_destination(target_rel) else {
+        return Ok(Vec::new());
+    };
+    let note_rels = collect_note_rels(root)?;
+    let mut mentions = Vec::new();
+    walk_notes(&notes_root(root), &mut |path, content| {
+        let source_rel = rel_of(root, path)?;
+        let mut occurrence = 0;
+        scan_content(content, |line, line_number, raw, wiki| {
+            let links_to_target = if wiki {
+                resolve_wiki(raw, &note_rels).as_deref() == Some(target.as_str())
+            } else {
+                normalize_destination(raw).as_deref() == Some(target.as_str())
+            };
+            if !links_to_target {
+                return;
+            }
+            mentions.push(BacklinkMention {
+                source_rel: source_rel.clone(),
+                context: clean_context(line),
+                line: line_number,
+                occurrence,
+            });
+            occurrence += 1;
+        });
+        Ok(())
+    })?;
+    mentions.sort_by(|a, b| {
+        a.source_rel
+            .to_lowercase()
+            .cmp(&b.source_rel.to_lowercase())
+            .then(a.line.cmp(&b.line))
+    });
+    Ok(mentions)
+}
+
+fn collect_note_rels(root: &Path) -> AppResult<Vec<String>> {
+    fn flatten(nodes: &[TreeNode], output: &mut Vec<String>) {
+        for node in nodes {
+            if node.kind == NodeKind::Note {
+                output.push(node.rel.clone());
+            } else if let Some(children) = &node.children {
+                flatten(children, output);
+            }
+        }
+    }
+
+    let mut rels = Vec::new();
+    flatten(&scan_tree(root)?, &mut rels);
+    Ok(rels)
+}
+
+/// Rewrite vault-relative Markdown link destinations after a note or folder
+/// moves. The Markdown files remain the rebuildable source of truth.
+pub fn rewrite_links(root: &Path, from: &str, to: &str) -> AppResult<usize> {
+    let mut changed_files = 0;
+    walk_notes(&notes_root(root), &mut |path, content| {
+        let mut output = String::with_capacity(content.len());
+        let mut changed = false;
+        let mut in_frontmatter = has_frontmatter(content);
+        let mut frontmatter_started = false;
+        let mut fence: Option<char> = None;
+
+        for segment in content.split_inclusive('\n') {
+            let (line, ending) = segment
+                .strip_suffix('\n')
+                .map(|value| (value, "\n"))
+                .unwrap_or((segment, ""));
+            let trimmed = line.trim_start();
+            if in_frontmatter {
+                if frontmatter_started && trimmed.trim_end() == "---" {
+                    in_frontmatter = false;
+                }
+                frontmatter_started = true;
+                output.push_str(line);
+                output.push_str(ending);
+                continue;
+            }
+            if let Some(marker) = fence_marker(trimmed) {
+                if fence == Some(marker) {
+                    fence = None;
+                } else if fence.is_none() {
+                    fence = Some(marker);
+                }
+                output.push_str(line);
+                output.push_str(ending);
+                continue;
+            }
+            if fence.is_some() {
+                output.push_str(line);
+                output.push_str(ending);
+                continue;
+            }
+
+            let rewritten = rewrite_line(line, from, to);
+            changed |= rewritten != line;
+            output.push_str(&rewritten);
+            output.push_str(ending);
+        }
+        if changed {
+            fs::write(path, output)?;
+            changed_files += 1;
+        }
+        Ok(())
+    })?;
+    Ok(changed_files)
+}
+
+fn walk_notes(dir: &Path, visit: &mut impl FnMut(&Path, &str) -> AppResult<()>) -> AppResult<()> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Ok(());
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        if path.is_dir() {
+            walk_notes(&path, visit)?;
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            let content = fs::read_to_string(&path).unwrap_or_default();
+            visit(&path, &content)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "backlinks_tests.rs"]
+mod tests;

--- a/src-tauri/src/backlinks_tests.rs
+++ b/src-tauri/src/backlinks_tests.rs
@@ -1,0 +1,106 @@
+use std::fs;
+
+use tempfile::tempdir;
+
+use super::*;
+use crate::notes::{create_folder, create_note, move_entry, write_note};
+use crate::vault::{ensure_layout, notes_root};
+
+#[test]
+fn finds_mentions_with_context_and_occurrence() {
+    let dir = tempdir().unwrap();
+    ensure_layout(dir.path()).unwrap();
+    let target = create_note(dir.path(), "", "Target Note").unwrap();
+    let source = create_note(dir.path(), "", "Source").unwrap();
+    write_note(
+        dir.path(),
+        &source,
+        "Before [first](Target%20Note.md) after.\n\n[second](Target%20Note.md)",
+    )
+    .unwrap();
+
+    let mentions = find_backlinks(dir.path(), &target).unwrap();
+    assert_eq!(mentions.len(), 2);
+    assert_eq!(mentions[0].context, "Before first after.");
+    assert_eq!(mentions[1].occurrence, 1);
+    assert_eq!(mentions[1].line, 3);
+}
+
+#[test]
+fn ignores_external_images_frontmatter_and_code() {
+    let dir = tempdir().unwrap();
+    ensure_layout(dir.path()).unwrap();
+    let target = create_note(dir.path(), "", "Target").unwrap();
+    let source = create_note(dir.path(), "", "Source").unwrap();
+    write_note(
+        dir.path(),
+        &source,
+        "---\nref: '[meta](Target.md)'\n---\n![image](Target.md)\n[web](https://example.com)\n```md\n[code](Target.md)\n```",
+    )
+    .unwrap();
+    assert!(find_backlinks(dir.path(), &target).unwrap().is_empty());
+}
+
+#[test]
+fn move_rewrites_links_and_rebuilds_mentions() {
+    let dir = tempdir().unwrap();
+    ensure_layout(dir.path()).unwrap();
+    let folder = create_folder(dir.path(), "", "Archive").unwrap();
+    let target = create_note(dir.path(), "", "Target Note").unwrap();
+    let source = create_note(dir.path(), "", "Source").unwrap();
+    write_note(
+        dir.path(),
+        &source,
+        "See [target](Target%20Note.md#details).",
+    )
+    .unwrap();
+
+    let moved = move_entry(dir.path(), &target, &folder).unwrap();
+    let content = fs::read_to_string(notes_root(dir.path()).join(&source)).unwrap();
+    assert!(content.contains("Archive/Target%20Note.md#details"));
+    assert_eq!(find_backlinks(dir.path(), &moved).unwrap().len(), 1);
+}
+
+#[test]
+fn malformed_percent_encoding_does_not_panic() {
+    assert_eq!(normalize_destination("notes/%aé.md"), Some("notes/%aé.md".into()));
+}
+
+#[test]
+fn resolves_wiki_links_by_path_then_filename() {
+    let dir = tempdir().unwrap();
+    ensure_layout(dir.path()).unwrap();
+    let folder = create_folder(dir.path(), "", "Projects").unwrap();
+    let target = create_note(dir.path(), &folder, "Roadmap").unwrap();
+    let source = create_note(dir.path(), "", "Source").unwrap();
+    write_note(
+        dir.path(),
+        &source,
+        "See [[Projects/Roadmap]] and [[Roadmap|the plan]].",
+    )
+    .unwrap();
+
+    let mentions = find_backlinks(dir.path(), &target).unwrap();
+    assert_eq!(mentions.len(), 2);
+    assert_eq!(mentions[0].context, "See Projects/Roadmap and the plan.");
+    assert_eq!(mentions[1].occurrence, 1);
+}
+
+#[test]
+fn scans_links_after_an_unclosed_frontmatter_delimiter() {
+    let dir = tempdir().unwrap();
+    ensure_layout(dir.path()).unwrap();
+    let folder = create_folder(dir.path(), "", "user-knowledgebase").unwrap();
+    let target = create_note(dir.path(), &folder, "about-saurabh").unwrap();
+    let source = create_note(dir.path(), &folder, "INDEX").unwrap();
+    write_note(
+        dir.path(),
+        &source,
+        "---\n\n## status: active\n\n[about-saurabh](user-knowledgebase/about-saurabh.md)",
+    )
+    .unwrap();
+
+    let mentions = find_backlinks(dir.path(), &target).unwrap();
+    assert_eq!(mentions.len(), 1);
+    assert_eq!(mentions[0].source_rel, "user-knowledgebase/INDEX.md");
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_dialog::DialogExt;
 
+use crate::backlinks::{self, BacklinkMention};
 use crate::bookmarks::{self, Bookmark};
 use crate::config::{self, Theme};
 use crate::error::{AppError, AppResult};
@@ -194,6 +195,11 @@ pub fn search_notes(
     limit: Option<usize>,
 ) -> AppResult<Vec<SearchHit>> {
     search::search_notes(&state.root()?, &query, limit.unwrap_or(30))
+}
+
+#[tauri::command]
+pub fn backlinks_for(state: State<'_, AppState>, rel: String) -> AppResult<Vec<BacklinkMention>> {
+    backlinks::find_backlinks(&state.root()?, &rel)
 }
 
 // ---- todos ----

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 mod agent_docs;
 mod assets;
+mod backlink_links;
+mod backlinks;
 mod bookmarks;
 mod commands;
 mod config;
@@ -34,6 +36,7 @@ pub fn run() {
             commands::move_entry,
             commands::delete_entry,
             commands::search_notes,
+            commands::backlinks_for,
             commands::todos_list,
             commands::todo_add,
             commands::todo_toggle,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::backlinks;
 use crate::error::{AppError, AppResult};
 use crate::util::sanitize_name;
 use crate::vault::{notes_root, rel_of, resolve_rel};
@@ -111,7 +112,9 @@ pub fn rename_entry(root: &Path, rel: &str, new_name: &str) -> AppResult<String>
         available_path(&dir, &name, Some("md"))
     };
     fs::rename(&path, &target)?;
-    rel_of(root, &target)
+    let next = rel_of(root, &target)?;
+    backlinks::rewrite_links(root, rel, &next)?;
+    Ok(next)
 }
 
 /// Move a note or folder into `target_dir_rel`. Returns the new rel path.
@@ -149,7 +152,9 @@ pub fn move_entry(root: &Path, rel: &str, target_dir_rel: &str) -> AppResult<Str
         available_path(&target_dir, &stem, Some("md"))
     };
     fs::rename(&path, &target)?;
-    rel_of(root, &target)
+    let next = rel_of(root, &target)?;
+    backlinks::rewrite_links(root, rel, &next)?;
+    Ok(next)
 }
 
 /// Move a note or folder to the OS trash.

--- a/src/components/editor/BacklinksSidebar.tsx
+++ b/src/components/editor/BacklinksSidebar.tsx
@@ -1,0 +1,59 @@
+import { PanelRight } from "lucide-react";
+import { motion } from "motion/react";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { SPRING_PANEL } from "@/lib/ease";
+import { cx } from "@/lib/utils";
+import { LinkedMentions } from "./LinkedMentions";
+
+const WIDTH = 280;
+
+export function BacklinksToggle({
+  open,
+  onToggle,
+}: {
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Tooltip label="Toggle linked mentions" side="bottom">
+      <button
+        type="button"
+        aria-pressed={open}
+        onClick={onToggle}
+        className={cx(
+          "grid h-7 w-7 place-items-center rounded-md border transition-[color,background-color,border-color,transform] duration-100 active:scale-[0.96]",
+          open
+            ? "border-invert bg-invert text-invert-ink"
+            : "border-line bg-hover text-muted hover:bg-active hover:text-ink",
+        )}
+      >
+        <PanelRight size={15} strokeWidth={1.85} />
+      </button>
+    </Tooltip>
+  );
+}
+
+export function BacklinksSidebar({
+  rel,
+  open,
+  onClose,
+}: {
+  rel: string | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const visible = Boolean(rel && open);
+
+  return (
+    <motion.div
+      animate={{ width: visible ? WIDTH : 0 }}
+      initial={false}
+      transition={SPRING_PANEL}
+      className="h-full shrink-0 overflow-hidden"
+    >
+      <div style={{ width: WIDTH }} className="h-full">
+        <LinkedMentions rel={rel ?? ""} active={visible} onClose={onClose} />
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/editor/LinkedMentions.tsx
+++ b/src/components/editor/LinkedMentions.tsx
@@ -1,0 +1,115 @@
+import { Link2, X } from "lucide-react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { BACKLINKS_CHANGED } from "@/lib/backlinks";
+import { ipc } from "@/lib/ipc";
+import type { BacklinkMention } from "@/lib/types";
+import { useTabs } from "@/stores/tabs";
+import { useVault } from "@/stores/vault";
+
+export const LinkedMentions = memo(function LinkedMentions({
+  rel,
+  active,
+  onClose,
+}: {
+  rel: string;
+  active: boolean;
+  onClose: () => void;
+}) {
+  const [mentions, setMentions] = useState<BacklinkMention[]>([]);
+  const [loading, setLoading] = useState(false);
+  const requestId = useRef(0);
+
+  const load = useCallback(async () => {
+    if (!active) return;
+    const request = ++requestId.current;
+    setLoading(true);
+    try {
+      const next = await ipc.backlinksFor(rel);
+      if (request === requestId.current) setMentions(next);
+    } catch {
+      if (request === requestId.current) setMentions([]);
+    } finally {
+      if (request === requestId.current) setLoading(false);
+    }
+  }, [active, rel]);
+
+  useEffect(() => {
+    if (!active) {
+      requestId.current += 1;
+      return;
+    }
+    void load();
+    const refresh = () => void load();
+    window.addEventListener(BACKLINKS_CHANGED, refresh);
+    window.addEventListener("focus", refresh);
+    return () => {
+      requestId.current += 1;
+      window.removeEventListener(BACKLINKS_CHANGED, refresh);
+      window.removeEventListener("focus", refresh);
+    };
+  }, [active, load]);
+
+  const openMention = (mention: BacklinkMention) => {
+    const vault = useVault.getState();
+    vault.expandTo(mention.sourceRel);
+    vault.setView({ type: "note", rel: mention.sourceRel });
+    useTabs
+      .getState()
+      .requestMentionFocus(mention.sourceRel, rel, mention.occurrence);
+  };
+
+  return (
+    <aside className="flex h-full w-[280px] flex-col border-l border-line-soft bg-panel">
+      <div className="flex h-11 shrink-0 items-center gap-2 px-3">
+        <Link2 size={14} strokeWidth={1.9} className="text-muted" />
+        <h2 className="text-[12.5px] font-semibold text-ink">
+          Linked mentions
+        </h2>
+        <span className="rounded-full bg-active px-1.5 py-0.5 text-[10px] tabular-nums text-muted">
+          {loading ? "·" : mentions.length}
+        </span>
+        <Tooltip label="Close linked mentions" side="left">
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-auto grid h-7 w-7 place-items-center rounded-md text-faint transition-colors duration-100 hover:bg-hover hover:text-ink"
+          >
+            <X size={14} strokeWidth={1.9} />
+          </button>
+        </Tooltip>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-4 pt-1">
+        {!loading && mentions.length === 0 ? (
+          <div className="px-2 py-8 text-center">
+            <p className="text-[12.5px] text-faint">No linked mentions yet.</p>
+            <p className="mt-1 text-[11.5px] leading-5 text-faint">
+              Notes linking here will appear in this panel.
+            </p>
+          </div>
+        ) : null}
+        {mentions.map((mention) => (
+          <button
+            key={`${mention.sourceRel}:${mention.line}:${mention.occurrence}`}
+            type="button"
+            onClick={() => openMention(mention)}
+            className="group block w-full rounded-md px-2 py-2.5 text-left transition-colors duration-100 hover:bg-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ink"
+          >
+            <span className="flex items-baseline justify-between gap-3">
+              <span className="truncate text-[12.5px] font-medium text-ink">
+                {mention.sourceRel.replace(/\.md$/i, "")}
+              </span>
+              <span className="shrink-0 text-[10.5px] tabular-nums text-faint">
+                Line {mention.line}
+              </span>
+            </span>
+            <span className="mt-1 block line-clamp-3 text-[12px] leading-[1.5] text-muted">
+              {mention.context || mention.sourceRel}
+            </span>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+});

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -10,6 +10,11 @@ import {
   type Property,
 } from "@/lib/frontmatter";
 import { hrefToRel, relToHref, wikiToMarkdown } from "@/lib/noteLinks";
+import {
+  containsMdx,
+  isMarkdownPaste,
+  stripMdxComponents,
+} from "@/lib/markdownPaste";
 import { flattenNotes } from "@/lib/tree";
 import { cx, debounce, noteTitle } from "@/lib/utils";
 import { useTabs } from "@/stores/tabs";
@@ -77,6 +82,10 @@ export const NoteEditor = memo(function NoteEditor({
   // True only while we're programmatically replacing the document, so the
   // resulting onUpdate doesn't mark the fresh content as an unsaved edit.
   const swapping = useRef(false);
+  // Editor props are installed when useEditor first runs, before the hook has
+  // returned its instance. A ref keeps paste and drop handlers connected to
+  // the live editor instead of the initial null render.
+  const editorRef = useRef<EditorInstance>(null);
 
   const persist = useCallback(
     async (markdown: string, targetRel: string) => {
@@ -161,13 +170,14 @@ export const NoteEditor = memo(function NoteEditor({
           "data-gramm": "false",
         },
         handlePaste(view, event) {
+          const currentEditor = editorRef.current;
           const image = Array.from(event.clipboardData?.files ?? []).find((f) =>
             f.type.startsWith("image/"),
           );
-          if (image && editor) {
+          if (image && currentEditor) {
             event.preventDefault();
             insertImageFile({
-              editor,
+              editor: currentEditor,
               file: image,
               range: {
                 from: view.state.selection.from,
@@ -177,13 +187,72 @@ export const NoteEditor = memo(function NoteEditor({
             });
             return true;
           }
+
+          const text = event.clipboardData?.getData("text/plain") ?? "";
+          const inCodeBlock = Boolean(
+            view.state.selection.$from.parent.type.spec.code,
+          );
+
+          const pasted = splitFrontmatter(text);
+          const importsDocument = Boolean(
+            currentEditor &&
+              !inCodeBlock &&
+              currentEditor.isEmpty &&
+              !frontmatter.current &&
+              pasted.frontmatter,
+          );
+          if (currentEditor && importsDocument) {
+            frontmatter.current = pasted.frontmatter;
+            setProperties(parseFrontmatter(pasted.frontmatter));
+            const notes = flattenNotes(useVault.getState().tree);
+            const richBody = containsMdx(pasted.body)
+              ? stripMdxComponents(pasted.body)
+              : pasted.body;
+            try {
+              const inserted = currentEditor.commands.insertContent(
+                wikiToMarkdown(richBody, notes),
+                { contentType: "markdown" },
+              );
+              if (inserted) {
+                event.preventDefault();
+                return true;
+              }
+            } catch {
+              // Fall through to native paste after restoring the prior state.
+            }
+            frontmatter.current = "";
+            setProperties([]);
+          }
+
+          if (currentEditor && !inCodeBlock && isMarkdownPaste(text)) {
+            const notes = flattenNotes(useVault.getState().tree);
+            const richText = containsMdx(text)
+              ? stripMdxComponents(text)
+              : text;
+            try {
+              const inserted = currentEditor.commands.insertContent(
+                wikiToMarkdown(richText, notes),
+                { contentType: "markdown" },
+              );
+              if (inserted) {
+                event.preventDefault();
+                return true;
+              }
+            } catch {
+              // MDX and other unsupported Markdown extensions cannot always be
+              // represented by the rich editor. Let native paste preserve the
+              // clipboard text instead of blocking the paste completely.
+            }
+          }
+
           return false;
         },
         handleDrop(view, event) {
+          const currentEditor = editorRef.current;
           const image = Array.from(event.dataTransfer?.files ?? []).find((f) =>
             f.type.startsWith("image/"),
           );
-          if (!image || !editor) return false;
+          if (!image || !currentEditor) return false;
           event.preventDefault();
           const coords = view.posAtCoords({
             left: event.clientX,
@@ -191,7 +260,7 @@ export const NoteEditor = memo(function NoteEditor({
           });
           const position = coords?.pos ?? view.state.selection.from;
           insertImageFile({
-            editor,
+            editor: currentEditor,
             file: image,
             range: { from: position, to: position },
             vaultRoot,
@@ -217,6 +286,7 @@ export const NoteEditor = memo(function NoteEditor({
     },
     [extensions],
   );
+  editorRef.current = editor;
 
   // Load the note (and swap in its content) whenever `rel` changes. The old
   // note's pending edit is flushed to *its* path first, before we switch.

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -2,6 +2,10 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import {
+  NOTES_REWRITTEN,
+  notifyBacklinksChanged,
+} from "@/lib/backlinks";
 import { ipc } from "@/lib/ipc";
 import {
   joinFrontmatter,
@@ -65,6 +69,7 @@ export const NoteEditor = memo(function NoteEditor({
   const [missing, setMissing] = useState(false);
   const [properties, setProperties] = useState<Property[]>([]);
   const [rawText, setRawText] = useState("");
+  const [loadNonce, setLoadNonce] = useState(0);
 
   const relRef = useRef(rel);
   // Frontmatter of the loaded note, kept out of the editor and re-attached on
@@ -95,6 +100,7 @@ export const NoteEditor = memo(function NoteEditor({
       const fullText = joinFrontmatter(frontmatter.current, markdown);
       try {
         await ipc.writeNote(targetRel, fullText);
+        notifyBacklinksChanged();
         if (relRef.current === targetRel) {
           lastSaved.current = fullText;
           setSaveState("idle");
@@ -210,7 +216,7 @@ export const NoteEditor = memo(function NoteEditor({
               : pasted.body;
             try {
               const inserted = currentEditor.commands.insertContent(
-                wikiToMarkdown(richBody, notes),
+                wikiToMarkdown(richBody, notes, relRef.current),
                 { contentType: "markdown" },
               );
               if (inserted) {
@@ -231,7 +237,7 @@ export const NoteEditor = memo(function NoteEditor({
               : text;
             try {
               const inserted = currentEditor.commands.insertContent(
-                wikiToMarkdown(richText, notes),
+                wikiToMarkdown(richText, notes, relRef.current),
                 { contentType: "markdown" },
               );
               if (inserted) {
@@ -319,10 +325,11 @@ export const NoteEditor = memo(function NoteEditor({
         setProperties(parseFrontmatter(fm));
         const notes = flattenNotes(useVault.getState().tree);
         swapping.current = true;
-        editor.commands.setContent(wikiToMarkdown(body, notes), {
+        editor.commands.setContent(wikiToMarkdown(body, notes, rel), {
           contentType: "markdown",
         });
         swapping.current = false;
+        setLoadNonce((value) => value + 1);
         setWords(countWords(body));
         // A freshly loaded note starts at the top.
         savedScroll.current = 0;
@@ -360,7 +367,7 @@ export const NoteEditor = memo(function NoteEditor({
     setProperties(parseFrontmatter(fm));
     const notes = flattenNotes(useVault.getState().tree);
     swapping.current = true;
-    editor.commands.setContent(wikiToMarkdown(body, notes), {
+    editor.commands.setContent(wikiToMarkdown(body, notes, relRef.current), {
       contentType: "markdown",
     });
     swapping.current = false;
@@ -391,10 +398,11 @@ export const NoteEditor = memo(function NoteEditor({
         setProperties(parseFrontmatter(fm));
         const notes = flattenNotes(useVault.getState().tree);
         swapping.current = true;
-        editor.commands.setContent(wikiToMarkdown(body, notes), {
+        editor.commands.setContent(wikiToMarkdown(body, notes, cur), {
           contentType: "markdown",
         });
         swapping.current = false;
+        setLoadNonce((value) => value + 1);
         setWords(countWords(body));
       }
     } catch {
@@ -406,8 +414,13 @@ export const NoteEditor = memo(function NoteEditor({
     const onFocus = () => {
       if (activeRef.current) reloadIfChanged();
     };
+    const onNotesRewritten = () => reloadIfChanged();
     window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
+    window.addEventListener(NOTES_REWRITTEN, onNotesRewritten);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener(NOTES_REWRITTEN, onNotesRewritten);
+    };
   }, [reloadIfChanged]);
 
   // On tab activation: restore the pane's scroll offset (display:none wiped
@@ -452,11 +465,61 @@ export const NoteEditor = memo(function NoteEditor({
   // Honor a scroll-to-top request for this note (fired when opened via a link).
   const scrollTopReq = useTabs((s) => s.scrollTopReq);
   const titleFocusReq = useTabs((s) => s.titleFocusReq);
+  const mentionFocusReq = useTabs((s) =>
+    s.mentionFocusReq?.rel === rel ? s.mentionFocusReq : null,
+  );
   useEffect(() => {
     if (!scrollTopReq || scrollTopReq.rel !== rel) return;
     savedScroll.current = 0;
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, [scrollTopReq, rel]);
+
+  useEffect(() => {
+    if (
+      !active ||
+      !editor ||
+      !mentionFocusReq ||
+      loadedRel.current !== rel
+    ) {
+      return;
+    }
+
+    let seen = -1;
+    let previousEnd = -1;
+    let match: { from: number; to: number } | null = null;
+    editor.state.doc.descendants((node, position) => {
+      if (!node.isText || match) return !match;
+      const linksToTarget = node.marks.some(
+        (mark) =>
+          mark.type.name === "link" &&
+          hrefToRel(mark.attrs.href as string | undefined) ===
+            mentionFocusReq.targetRel,
+      );
+      if (!linksToTarget) {
+        previousEnd = -1;
+        return true;
+      }
+      if (position !== previousEnd) seen += 1;
+      previousEnd = position + node.nodeSize;
+      if (seen === mentionFocusReq.occurrence) {
+        match = { from: position, to: position + node.nodeSize };
+        return false;
+      }
+      return true;
+    });
+
+    if (match) {
+      editor
+        .chain()
+        .focus()
+        .setTextSelection(match)
+        .scrollIntoView()
+        .run();
+    } else {
+      savedScroll.current = 0;
+      if (scrollRef.current) scrollRef.current.scrollTop = 0;
+    }
+  }, [active, editor, loadNonce, mentionFocusReq, rel]);
 
   const flushThen = (action: () => void) => {
     debouncedPersist.cancel();
@@ -594,7 +657,7 @@ export const NoteEditor = memo(function NoteEditor({
       {active && (
         <div
           className={cx(
-            "pointer-events-none fixed bottom-3 right-4 text-[11px] tabular-nums text-faint transition-opacity duration-300",
+            "pointer-events-none absolute bottom-3 right-4 text-[11px] tabular-nums text-faint transition-opacity duration-300",
             (words === 0 || missing) && "opacity-0",
           )}
         >

--- a/src/components/editor/NoteLinkPicker.tsx
+++ b/src/components/editor/NoteLinkPicker.tsx
@@ -2,6 +2,7 @@ import { FileText } from "lucide-react";
 import { motion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { flattenNotes } from "@/lib/tree";
+import { relToLabel } from "@/lib/noteLinks";
 import { cx, noteTitle, parentDir } from "@/lib/utils";
 import { useVault } from "@/stores/vault";
 
@@ -66,7 +67,7 @@ export function NoteLinkPicker({
 
   const choose = (index: number) => {
     const note = filtered[index];
-    if (note) onPick(note.rel, noteTitle(note.rel));
+    if (note) onPick(note.rel, relToLabel(note.rel, currentRel));
   };
 
   return (

--- a/src/components/editor/NotesWorkspace.tsx
+++ b/src/components/editor/NotesWorkspace.tsx
@@ -22,7 +22,10 @@ export function NotesWorkspace({ visible }: { visible: boolean }) {
       {tabs.map((rel) => (
         <div
           key={rel}
-          className={cx("absolute inset-0", rel !== active && "hidden")}
+          className={cx(
+            "absolute inset-0 overflow-hidden",
+            rel !== active && "hidden",
+          )}
         >
           <NoteEditor rel={rel} active={visible && rel === active} />
         </div>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,6 +1,23 @@
-import { Check, Code2, Copy, Download, FilePlus, MoreVertical, PanelLeft, Pilcrow, Search, Tag, Trash2, X } from "lucide-react";
+import {
+  Check,
+  Code2,
+  Copy,
+  Download,
+  FilePlus,
+  MoreVertical,
+  PanelLeft,
+  Pilcrow,
+  Search,
+  Tag,
+  Trash2,
+  X,
+} from "lucide-react";
 import { AnimatePresence, LayoutGroup, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
+import {
+  BacklinksSidebar,
+  BacklinksToggle,
+} from "@/components/editor/BacklinksSidebar";
 import { NoteBreadcrumb } from "@/components/editor/NoteBreadcrumb";
 import { NotesWorkspace } from "@/components/editor/NotesWorkspace";
 import { TabBar } from "@/components/editor/TabBar";
@@ -43,8 +60,10 @@ export function AppShell() {
   const view = useVault((s) => s.view);
   const root = useVault((s) => s.root);
   const sidebarHidden = useUi((s) => s.sidebarHidden);
+  const backlinksHidden = useUi((s) => s.backlinksHidden);
   const markdownSource = useUi((s) => s.markdownSource);
   const toggleSidebar = useUi((s) => s.toggleSidebar);
+  const toggleBacklinks = useUi((s) => s.toggleBacklinks);
   const toggleMarkdownSource = useUi((s) => s.toggleMarkdownSource);
   const createBookmarkTag = useBookmarks((s) => s.createTag);
   const exportBookmarks = useBookmarks((s) => s.exportAll);
@@ -113,6 +132,12 @@ export function AppShell() {
 
           <LayoutGroup>
             <div className="ml-auto flex items-center gap-2">
+              {view?.type === "note" && (
+                <BacklinksToggle
+                  open={!backlinksHidden}
+                  onToggle={toggleBacklinks}
+                />
+              )}
               {view?.type === "note" && (
                 <Tooltip
                   label={markdownSource ? "Show rich editor" : "Show Markdown source"}
@@ -240,6 +265,12 @@ export function AppShell() {
           {!view && <EmptyState />}
         </div>
       </main>
+
+      <BacklinksSidebar
+        rel={view?.type === "note" ? view.rel : null}
+        open={!backlinksHidden}
+        onClose={toggleBacklinks}
+      />
     </div>
   );
 }

--- a/src/lib/backlinks.ts
+++ b/src/lib/backlinks.ts
@@ -1,0 +1,11 @@
+export const BACKLINKS_CHANGED = "markd:backlinks-changed";
+export const NOTES_REWRITTEN = "markd:notes-rewritten";
+
+export function notifyBacklinksChanged() {
+  window.dispatchEvent(new Event(BACKLINKS_CHANGED));
+}
+
+export function notifyNotesRewritten() {
+  window.dispatchEvent(new Event(NOTES_REWRITTEN));
+  notifyBacklinksChanged();
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  BacklinkMention,
   Bookmark,
   SearchHit,
   Theme,
@@ -53,6 +54,8 @@ export const ipc = {
   deleteEntry: (rel: string) => call<void>("delete_entry", { rel }),
   searchNotes: (query: string, limit?: number) =>
     call<SearchHit[]>("search_notes", { query, limit }),
+  backlinksFor: (rel: string) =>
+    call<BacklinkMention[]>("backlinks_for", { rel }),
 
   todosList: () => call<Todo[]>("todos_list"),
   todoAdd: (text: string) => call<Todo>("todo_add", { text }),

--- a/src/lib/markdownPaste.ts
+++ b/src/lib/markdownPaste.ts
@@ -1,0 +1,49 @@
+const BLOCK_MARKDOWN = [
+  /^ {0,3}#{1,6}[ \t]+\S/m,
+  /^ {0,3}(?:[-+*]|\d+[.)])[ \t]+\S/m,
+  /^ {0,3}>[ \t]+\S/m,
+  /^ {0,3}```[^\n]*$/m,
+  /^ {0,3}~~~[^\n]*$/m,
+  /^ {0,3}(?:-{3,}|\*{3,}|_{3,})[ \t]*$/m,
+  /^ {0,3}-[ \t]+\[[ xX]\][ \t]+\S/m,
+  /^\s*\|?.+\|.+\r?\n\s*\|?[ \t]*:?-{3,}:?[ \t]*\|/m,
+];
+
+const INLINE_MARKDOWN = [
+  /!\[[^\]]*\]\([^\n)]+\)/,
+  /\[[^\]\n]+\]\([^\n)]+\)/,
+  /(?:\*\*|__)[^\n]+(?:\*\*|__)/,
+  /~~[^\n~]+~~/,
+  /`[^\n`]+`/,
+];
+
+const MDX_COMPONENT = /^\s*<\/?[A-Z][A-Za-z0-9.]*(?:\s|\/?>)/m;
+
+/** Rich Tiptap nodes cannot safely round-trip arbitrary MDX components. */
+export function containsMdx(text: string) {
+  return MDX_COMPONENT.test(text);
+}
+
+/**
+ * Rich notes cannot execute MDX components. Remove their tags while retaining
+ * the readable Markdown and text nested between opening and closing tags.
+ */
+export function stripMdxComponents(text: string) {
+  return text.replace(
+    /<\/?[A-Z][A-Za-z0-9.]*(?:\s[^<>]*?)?\s*\/?>/g,
+    "",
+  );
+}
+
+/**
+ * Detect pasted text that should be parsed as Markdown instead of being left
+ * to the browser's clipboard HTML handling. This intentionally requires real
+ * Markdown syntax so ordinary prose keeps its native paste behavior.
+ */
+export function isMarkdownPaste(text: string) {
+  const value = text.trim();
+  if (!value) return false;
+  return [...BLOCK_MARKDOWN, ...INLINE_MARKDOWN].some((pattern) =>
+    pattern.test(value),
+  );
+}

--- a/src/lib/noteLinks.ts
+++ b/src/lib/noteLinks.ts
@@ -29,6 +29,16 @@ export function relToHref(rel: string): string {
   return rel.split("/").map(encodeURIComponent).join("/");
 }
 
+/** Vault rel → visible label, relative when it sits below the current note. */
+export function relToLabel(rel: string, fromRel?: string): string {
+  const label = rel.replace(/\.md$/i, "");
+  const fromDir = fromRel?.split("/").slice(0, -1).join("/");
+  if (fromDir && label.startsWith(`${fromDir}/`)) {
+    return label.slice(fromDir.length + 1);
+  }
+  return label;
+}
+
 /**
  * Resolve a `[[wiki]]` target to a note. Matches by full rel first, then by
  * bare filename anywhere in the vault (wiki-style); falls back to a
@@ -37,6 +47,7 @@ export function relToHref(rel: string): string {
 export function resolveWiki(
   target: string,
   notes: { rel: string }[],
+  fromRel?: string,
 ): { rel: string; title: string } {
   const clean = target.trim().replace(/\.md$/i, "");
   const lower = clean.toLowerCase();
@@ -51,7 +62,7 @@ export function resolveWiki(
           lower,
       );
   const rel = (byRel ?? byName)?.rel ?? `${clean}.md`;
-  const title = (rel.split("/").pop() ?? rel).replace(/\.md$/i, "");
+  const title = relToLabel(rel, fromRel);
   return { rel, title };
 }
 
@@ -63,13 +74,56 @@ export function resolveWiki(
 export function wikiToMarkdown(
   markdown: string,
   notes: { rel: string }[],
+  fromRel?: string,
 ): string {
-  return markdown.replace(
+  const withWikiLinks = markdown.replace(
     /\[\[([^[\]|]+)(?:\|([^[\]]+))?\]\]/g,
     (_, target: string, alias?: string) => {
-      const { rel, title } = resolveWiki(target, notes);
+      const { rel, title } = resolveWiki(target, notes, fromRel);
       const text = (alias ?? title).trim();
       return `[${text}](${relToHref(rel)})`;
+    },
+  );
+
+  return expandDefaultLinkLabels(withWikiLinks, notes, fromRel);
+}
+
+/** Expand basename-only labels for existing links to nested notes. */
+export function expandDefaultLinkLabels(
+  markdown: string,
+  notes: { rel: string }[],
+  fromRel?: string,
+): string {
+  const noteRels = new Map(
+    notes.map((note) => [note.rel.toLowerCase(), note.rel]),
+  );
+
+  return markdown.replace(
+    /(?<!!)\[([^\]]+)\]\(([^)\s]+)(?:\s+("[^"]*"|'[^']*'))?\)/g,
+    (match, label: string, href: string, title?: string) => {
+      let candidate: string | null;
+      try {
+        candidate = hrefToRel(href);
+      } catch {
+        return match;
+      }
+      if (!candidate) return match;
+
+      const rel = noteRels.get(candidate.toLowerCase());
+      if (!rel || !rel.includes("/")) return match;
+
+      const filename = rel.split("/").pop()?.replace(/\.md$/i, "") ?? "";
+      const fullLabel = relToLabel(rel);
+      const currentLabel = label.trim().toLowerCase();
+      if (
+        currentLabel !== filename.toLowerCase() &&
+        currentLabel !== fullLabel.toLowerCase()
+      ) {
+        return match;
+      }
+
+      const suffix = title ? ` ${title}` : "";
+      return `[${relToLabel(rel, fromRel)}](${href}${suffix})`;
     },
   );
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,13 @@ export interface SearchHit {
   titleMatch: boolean;
 }
 
+export interface BacklinkMention {
+  sourceRel: string;
+  context: string;
+  line: number;
+  occurrence: number;
+}
+
 export type View =
   | { type: "note"; rel: string }
   | { type: "todos" }

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -11,6 +11,13 @@ interface TabsState {
   scrollTopReq: { rel: string; nonce: number } | null;
   /** Bumped to ask a newly created note to select its title. */
   titleFocusReq: { rel: string; nonce: number } | null;
+  /** Bumped to focus a specific link occurrence after opening a backlink. */
+  mentionFocusReq: {
+    rel: string;
+    targetRel: string;
+    occurrence: number;
+    nonce: number;
+  } | null;
   /** Add a tab for `rel` if not already open (no-op otherwise). */
   open: (rel: string) => void;
   close: (rel: string) => void;
@@ -22,6 +29,12 @@ interface TabsState {
   requestScrollTop: (rel: string) => void;
   /** Request that `rel`'s title input receive focus and select its text. */
   requestTitleFocus: (rel: string) => void;
+  /** Request that a source note reveal its link to `targetRel`. */
+  requestMentionFocus: (
+    rel: string,
+    targetRel: string,
+    occurrence: number,
+  ) => void;
   clear: () => void;
 }
 
@@ -29,6 +42,7 @@ export const useTabs = create<TabsState>((set, get) => ({
   tabs: [],
   scrollTopReq: null,
   titleFocusReq: null,
+  mentionFocusReq: null,
 
   open: (rel) => {
     if (!get().tabs.includes(rel)) set({ tabs: [...get().tabs, rel] });
@@ -61,7 +75,23 @@ export const useTabs = create<TabsState>((set, get) => ({
       },
     }),
 
-  clear: () => set({ tabs: [], scrollTopReq: null, titleFocusReq: null }),
+  requestMentionFocus: (rel, targetRel, occurrence) =>
+    set({
+      mentionFocusReq: {
+        rel,
+        targetRel,
+        occurrence,
+        nonce: (get().mentionFocusReq?.nonce ?? 0) + 1,
+      },
+    }),
+
+  clear: () =>
+    set({
+      tabs: [],
+      scrollTopReq: null,
+      titleFocusReq: null,
+      mentionFocusReq: null,
+    }),
 }));
 
 /** Tab to activate after closing `rel`: right neighbor, else left, else none. */

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -6,11 +6,13 @@ interface UiState {
   paletteOpen: boolean;
   settingsOpen: boolean;
   sidebarHidden: boolean;
+  backlinksHidden: boolean;
   markdownSource: boolean;
   saveState: SaveState;
   setPaletteOpen: (open: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
   toggleSidebar: () => void;
+  toggleBacklinks: () => void;
   toggleMarkdownSource: () => void;
   setSaveState: (state: SaveState) => void;
 }
@@ -19,11 +21,13 @@ export const useUi = create<UiState>((set, get) => ({
   paletteOpen: false,
   settingsOpen: false,
   sidebarHidden: false,
+  backlinksHidden: true,
   markdownSource: false,
   saveState: "idle",
   setPaletteOpen: (paletteOpen) => set({ paletteOpen }),
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
   toggleSidebar: () => set({ sidebarHidden: !get().sidebarHidden }),
+  toggleBacklinks: () => set({ backlinksHidden: !get().backlinksHidden }),
   toggleMarkdownSource: () =>
     set({ markdownSource: !get().markdownSource }),
   setSaveState: (saveState) => set({ saveState }),

--- a/src/stores/vault.ts
+++ b/src/stores/vault.ts
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 import { toast } from "sonner";
 import { ipc } from "@/lib/ipc";
+import {
+  notifyBacklinksChanged,
+  notifyNotesRewritten,
+} from "@/lib/backlinks";
 import type { Theme, TreeNode, VaultSnapshot, View } from "@/lib/types";
 import { parentDir } from "@/lib/utils";
 import { useTabs } from "@/stores/tabs";
@@ -209,6 +213,7 @@ export const useVault = create<VaultState>((set, get) => ({
       // Route through setView so the tab opens (blank pane otherwise).
       get().setView({ type: "note", rel });
       useTabs.getState().requestTitleFocus(rel);
+      notifyBacklinksChanged();
     } catch (err) {
       oops(err);
     }
@@ -240,6 +245,7 @@ export const useVault = create<VaultState>((set, get) => ({
           set({ view: { type: "note", rel: view.rel.replace(rel, next) } });
         }
       }
+      notifyNotesRewritten();
     } catch (err) {
       oops(err);
     }
@@ -260,6 +266,7 @@ export const useVault = create<VaultState>((set, get) => ({
           set({ view: { type: "note", rel: view.rel.replace(rel, next) } });
         }
       }
+      notifyNotesRewritten();
     } catch (err) {
       oops(err);
     }
@@ -287,6 +294,7 @@ export const useVault = create<VaultState>((set, get) => ({
       toast("Moved to Trash", {
         description: rel.split("/").pop()?.replace(/\.md$/, ""),
       });
+      notifyBacklinksChanged();
     } catch (err) {
       oops(err);
     }

--- a/tests/markdownPaste.test.ts
+++ b/tests/markdownPaste.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { splitFrontmatter } from "../src/lib/frontmatter";
+import {
+  containsMdx,
+  isMarkdownPaste,
+  stripMdxComponents,
+} from "../src/lib/markdownPaste";
+
+describe("isMarkdownPaste", () => {
+  test("recognizes a heading followed by a list", () => {
+    expect(
+      isMarkdownPaste(`### 1. Backlinks and linked mentions
+
+Show every note that links to the active note.
+
+- Resolve links by vault-relative Markdown path.
+- Keep the index local and rebuildable.`),
+    ).toBe(true);
+  });
+
+  test("recognizes common block and inline Markdown", () => {
+    expect(isMarkdownPaste("> A quoted paragraph")).toBe(true);
+    expect(isMarkdownPaste("```ts\nconst value = true\n```")).toBe(true);
+    expect(isMarkdownPaste("Read **this carefully**.")).toBe(true);
+    expect(isMarkdownPaste("[Markd](https://usemarkd.app)")).toBe(true);
+  });
+
+  test("leaves ordinary prose to native paste handling", () => {
+    expect(isMarkdownPaste("A normal sentence with no special formatting.")).toBe(
+      false,
+    );
+    expect(isMarkdownPaste("First paragraph.\n\nSecond paragraph.")).toBe(false);
+  });
+
+  test("recognizes MDX components that need literal paste", () => {
+    expect(
+      containsMdx(`<ComponentPreview
+  styleName="base-nova"
+  name="accordion-demo"
+/>`),
+    ).toBe(true);
+    expect(containsMdx('<TabsContent value="manual">')).toBe(true);
+    expect(containsMdx("<p>Regular HTML</p>")).toBe(false);
+  });
+
+  test("removes MDX tags but keeps their readable content", () => {
+    const source = `<TabsContent value="manual">
+
+<Step>Install the following dependencies:</Step>
+
+<ComponentPreview name="accordion-demo" />
+
+## Installation
+
+</TabsContent>`;
+
+    const richText = stripMdxComponents(source);
+    expect(richText).toContain("Install the following dependencies:");
+    expect(richText).toContain("## Installation");
+    expect(richText).not.toContain("TabsContent");
+    expect(richText).not.toContain("ComponentPreview");
+  });
+
+  test("extracts pasted frontmatter before checking an MDX body", () => {
+    const source = `---
+title: Accordion
+component: true
+links:
+  doc: https://base-ui.com/react/components/accordion
+---
+
+<ComponentPreview name="accordion-demo" />
+
+## Installation`;
+    const note = splitFrontmatter(source);
+
+    expect(note.frontmatter).toContain("title: Accordion");
+    expect(note.body).toStartWith("\n<ComponentPreview");
+    expect(containsMdx(note.body)).toBe(true);
+  });
+});

--- a/tests/noteLinks.test.ts
+++ b/tests/noteLinks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import {
+  expandDefaultLinkLabels,
+  relToLabel,
+  resolveWiki,
+  wikiToMarkdown,
+} from "../src/lib/noteLinks";
+
+const notes = [
+  { rel: "Root.md" },
+  { rel: "projects/Roadmap.md" },
+];
+
+describe("note link labels", () => {
+  test("keeps folder context in default labels", () => {
+    expect(relToLabel("projects/Roadmap.md")).toBe("projects/Roadmap");
+    expect(resolveWiki("Roadmap", notes)).toEqual({
+      rel: "projects/Roadmap.md",
+      title: "projects/Roadmap",
+    });
+  });
+
+  test("makes labels relative to the current note folder", () => {
+    expect(
+      relToLabel(
+        "user-knowledgebase/projects/Roadmap.md",
+        "user-knowledgebase/INDEX.md",
+      ),
+    ).toBe("projects/Roadmap");
+    expect(
+      relToLabel(
+        "user-knowledgebase/About.md",
+        "user-knowledgebase/INDEX.md",
+      ),
+    ).toBe("About");
+  });
+
+  test("keeps explicit wiki aliases", () => {
+    expect(wikiToMarkdown("[[Roadmap|plan]]", notes)).toBe(
+      "[plan](projects/Roadmap.md)",
+    );
+  });
+
+  test("expands existing nested note labels in the editor", () => {
+    expect(
+      expandDefaultLinkLabels("[Roadmap](projects/Roadmap.md)", notes),
+    ).toBe("[projects/Roadmap](projects/Roadmap.md)");
+  });
+
+  test("removes the containing note folder from existing labels", () => {
+    const nestedNotes = [
+      { rel: "user-knowledgebase/INDEX.md" },
+      { rel: "user-knowledgebase/projects/Roadmap.md" },
+    ];
+    expect(
+      expandDefaultLinkLabels(
+        "[user-knowledgebase/projects/Roadmap](user-knowledgebase/projects/Roadmap.md)",
+        nestedNotes,
+        "user-knowledgebase/INDEX.md",
+      ),
+    ).toBe("[projects/Roadmap](user-knowledgebase/projects/Roadmap.md)");
+  });
+
+  test("preserves aliases, external links, images, and root note labels", () => {
+    const markdown = [
+      "[plan](projects/Roadmap.md)",
+      "[site](https://example.com)",
+      "![Roadmap](projects/Roadmap.md)",
+      "[Root](Root.md)",
+    ].join("\n");
+
+    expect(expandDefaultLinkLabels(markdown, notes)).toBe(markdown);
+  });
+});


### PR DESCRIPTION
## Summary

- add a local, rebuildable backlink index for Markdown and wiki links
- show linked mentions in a collapsible right sidebar with source context
- keep backlinks current across edits, renames, moves, creates, and deletes
- open linked mentions at the relevant link occurrence when possible
- improve Markdown paste parsing and context-aware internal link labels

## Verification

- `cargo test` (34 passed)
- `bun test tests/noteLinks.test.ts tests/markdownPaste.test.ts` (12 passed)
- `bunx tsc --noEmit`