### PR TITLE
feat: add editable note properties

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Rust owns the filesystem; the frontend is UI + state only. All IO goes through t
 
 User picks any folder as a vault:
 
-- `<vault>/notes/` — plain `.md` files, filename = title, no IDs. Folders are real folders. Portable plain-markdown. The app never *authors* frontmatter, but preserves and renders any that external tools (e.g. web clippers) added — see below.
+- `<vault>/notes/` — plain `.md` files, filename = title, no IDs. Folders are real folders. Portable plain-markdown. Frontmatter is optional: Markd preserves external YAML and only authors flat properties after an explicit user action in the Properties UI.
 - `<vault>/.markd/` — app data: `todos.json`, `bookmarks.json`, `assets/` (pasted images).
 - Vault path + theme persist in the app config dir (`config.json`).
 
@@ -47,7 +47,7 @@ Blocking dialogs (`blocking_pick_folder`) must run in async commands via `spawn_
 - Tabs: `NotesWorkspace` keeps one live editor per open tab, inactive panes hidden via `display:none` — tab switch is a CSS toggle, never a remount/re-parse. Keep it that way.
 - Session: `lib/session.ts` persists per-vault UI layout (open tabs, active view, todo/bookmark tag filters) to localStorage keyed by vault root, restoring it on launch. Tag filters live in the `todos`/`bookmarks` stores (not component state) so they're subscribable.
 - Page links: internal note links are plain markdown links whose href is a vault-relative note path (`[Title](projects/app.md)`). `lib/noteLinks.ts` converts href↔rel and rewrites `[[wiki]]`/`[[target|alias]]` syntax (on type + on load) into those markdown links; clicking one opens the note; `/link` slash command + `NoteLinkPicker` also insert them.
-- Frontmatter: `lib/frontmatter.ts` splits a leading `---` YAML block off the body on load and re-attaches it verbatim on save (so metadata round-trips), and parses it for the read-only `NoteProperties` panel shown above the editor. The editor body never contains the raw YAML.
+- Frontmatter: `lib/frontmatter.ts` splits a leading `---` YAML block off the body on load and re-attaches it on save. `NoteProperties` can add, edit, and remove flat text or list properties while preserving unrelated YAML. The editor body never contains the raw YAML.
 
 ## UI conventions
 
@@ -76,4 +76,4 @@ Our `Modal` (`components/ui/Modal.tsx`) is built on the same tokens; keep new di
 
 - Never add "Co-Authored-By" or any AI attribution to commits or PRs.
 - Commit messages: conventional commits, subject ≤50 chars where possible.
-- Don't reintroduce: sticky notes, note IDs, plugin-fs. Don't *author* frontmatter (external frontmatter is preserved/rendered, not written by us). `[[wiki]]` is accepted as input but stored as standard markdown `[title](path.md)` links.
+- Don't reintroduce: sticky notes, note IDs, plugin-fs. Never add frontmatter automatically; only explicit actions in the Properties UI may author it. `[[wiki]]` is accepted as input but stored as standard markdown `[title](path.md)` links.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Double-click Markd → click **Done** → **System Settings → Privacy & Securi
 - **⌘K command palette** — jump to any note, folder, or page instantly
 - **Instant search** — title + content, ranked, in milliseconds
 - **Monochrome UI** — light, dark, or system theme; no color noise
-- **Portable vault** — plain files, no IDs, no frontmatter, no lock-in
+- **Portable vault** — plain files, no IDs, no required metadata, no lock-in
 
 ---
 

--- a/src-tauri/src/agent_docs.rs
+++ b/src-tauri/src/agent_docs.rs
@@ -25,8 +25,8 @@ and edit it directly with ordinary file tools.
 
 - Plain Markdown (CommonMark + GFM — tables, task lists, fenced code).
 - A note may begin with a YAML frontmatter block delimited by `---`.
-  **Preserve it** when editing; Markd renders it as a read-only properties
-  panel and never authors it itself.
+  **Preserve it** when editing; Markd renders it as an editable properties
+  panel and only authors it after an explicit user action.
 - Internal page links are Markdown links whose target is a note path relative
   to `notes/`, e.g. `[Roadmap](projects/roadmap.md)`. `[[wiki]]` and
   `[[target|alias]]` links are also understood.

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -10,8 +10,10 @@ import { ipc } from "@/lib/ipc";
 import {
   joinFrontmatter,
   parseFrontmatter,
+  removeFrontmatterProperty,
   splitFrontmatter,
   type Property,
+  upsertFrontmatterProperty,
 } from "@/lib/frontmatter";
 import { hrefToRel, relToHref, wikiToMarkdown } from "@/lib/noteLinks";
 import {
@@ -293,6 +295,35 @@ export const NoteEditor = memo(function NoteEditor({
     [extensions],
   );
   editorRef.current = editor;
+
+  const applyFrontmatter = useCallback(
+    (nextFrontmatter: string) => {
+      if (!editor) return;
+      frontmatter.current = nextFrontmatter;
+      setProperties(parseFrontmatter(nextFrontmatter));
+      const markdown = editor.getMarkdown();
+      pending.current = markdown;
+      setSaveState("saving");
+      debouncedPersist(markdown);
+    },
+    [debouncedPersist, editor, setSaveState],
+  );
+
+  const upsertProperty = useCallback(
+    (previousKey: string | null, property: Property) => {
+      applyFrontmatter(
+        upsertFrontmatterProperty(frontmatter.current, previousKey, property),
+      );
+    },
+    [applyFrontmatter],
+  );
+
+  const removeProperty = useCallback(
+    (key: string) => {
+      applyFrontmatter(removeFrontmatterProperty(frontmatter.current, key));
+    },
+    [applyFrontmatter],
+  );
 
   // Load the note (and swap in its content) whenever `rel` changes. The old
   // note's pending edit is flushed to *its* path first, before we switch.
@@ -622,7 +653,11 @@ export const NoteEditor = memo(function NoteEditor({
             </Suspense>
           ) : (
             <>
-              <NoteProperties properties={properties} />
+              <NoteProperties
+                properties={properties}
+                onUpsert={upsertProperty}
+                onRemove={removeProperty}
+              />
               <EditorContent editor={editor} />
             </>
           )}

--- a/src/components/editor/NoteEditor.tsx
+++ b/src/components/editor/NoteEditor.tsx
@@ -70,6 +70,7 @@ export const NoteEditor = memo(function NoteEditor({
   const [words, setWords] = useState(0);
   const [missing, setMissing] = useState(false);
   const [properties, setProperties] = useState<Property[]>([]);
+  const [propertyAddRequest, setPropertyAddRequest] = useState(0);
   const [rawText, setRawText] = useState("");
   const [loadNonce, setLoadNonce] = useState(0);
 
@@ -325,6 +326,11 @@ export const NoteEditor = memo(function NoteEditor({
     [applyFrontmatter],
   );
 
+  const consumePropertyAddRequest = useCallback(
+    () => setPropertyAddRequest(0),
+    [],
+  );
+
   // Load the note (and swap in its content) whenever `rel` changes. The old
   // note's pending edit is flushed to *its* path first, before we switch.
   useEffect(() => {
@@ -570,7 +576,9 @@ export const NoteEditor = memo(function NoteEditor({
           ? rawText
           : joinFrontmatter(frontmatter.current, editor.getMarkdown());
 
-        if (action === "copy") {
+        if (action === "add-property") {
+          setPropertyAddRequest((request) => request + 1);
+        } else if (action === "copy") {
           await navigator.clipboard.writeText(markdown);
           toast("Markdown copied");
         } else if (action === "export") {
@@ -655,6 +663,8 @@ export const NoteEditor = memo(function NoteEditor({
             <>
               <NoteProperties
                 properties={properties}
+                addRequest={propertyAddRequest}
+                onAddRequestHandled={consumePropertyAddRequest}
                 onUpsert={upsertProperty}
                 onRemove={removeProperty}
               />

--- a/src/components/editor/NoteProperties.tsx
+++ b/src/components/editor/NoteProperties.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight, Pencil, Plus } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Property } from "@/lib/frontmatter";
 import { EASE_OUT } from "@/lib/ease";
 import { cx, hostOf } from "@/lib/utils";
@@ -10,82 +10,95 @@ type EditorState = { property: Property | null } | null;
 
 export function NoteProperties({
   properties,
+  addRequest,
+  onAddRequestHandled,
   onUpsert,
   onRemove,
 }: {
   properties: Property[];
+  addRequest: number;
+  onAddRequestHandled: () => void;
   onUpsert: (previousKey: string | null, property: Property) => void;
   onRemove: (key: string) => void;
 }) {
   const [open, setOpen] = useState(true);
   const [editor, setEditor] = useState<EditorState>(null);
 
+  useEffect(() => {
+    if (addRequest === 0) return;
+    setOpen(true);
+    setEditor({ property: null });
+    onAddRequestHandled();
+  }, [addRequest, onAddRequestHandled]);
+
+  const propertyEditor = editor ? (
+    <PropertyEditorModal
+      key={editor.property?.key ?? "new"}
+      property={editor.property}
+      existingKeys={properties.map((property) => property.key)}
+      onClose={() => setEditor(null)}
+      onSave={onUpsert}
+      onDelete={onRemove}
+    />
+  ) : null;
+
+  if (properties.length === 0) return propertyEditor;
+
   return (
-    <div className="mb-5 mt-1 border-b border-line pb-3">
-      <div className="mb-1 flex items-center">
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-faint transition-colors hover:text-muted"
-        >
-          <ChevronRight
-            size={12}
-            strokeWidth={2.5}
-            className={cx(
-              "transition-transform duration-150",
-              open && "rotate-90",
-            )}
-          />
-          Properties
-          {properties.length > 0 && (
+    <>
+      <div className="mb-5 mt-1 border-b border-line pb-3">
+        <div className="mb-1 flex items-center">
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-faint transition-colors hover:text-muted"
+          >
+            <ChevronRight
+              size={12}
+              strokeWidth={2.5}
+              className={cx(
+                "transition-transform duration-150",
+                open && "rotate-90",
+              )}
+            />
+            Properties
             <span className="ml-0.5 font-mono text-[9.5px] font-normal tracking-normal">
               {properties.length}
             </span>
-          )}
-        </button>
-        <button
-          type="button"
-          aria-label="Add property"
-          title="Add property"
-          onClick={() => {
-            setOpen(true);
-            setEditor({ property: null });
-          }}
-          className="ml-auto grid h-6 w-6 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink"
-        >
-          <Plus size={13} strokeWidth={2} />
-        </button>
-      </div>
-
-      <AnimatePresence initial={false}>
-        {open && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.16, ease: EASE_OUT }}
-            className="overflow-hidden"
+          </button>
+          <button
+            type="button"
+            aria-label="Add property"
+            title="Add property"
+            onClick={() => {
+              setOpen(true);
+              setEditor({ property: null });
+            }}
+            className="ml-auto grid h-6 w-6 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink"
           >
-            <div className="flex flex-col gap-0.5 pt-1">
-              {properties.length === 0 ? (
-                <button
-                  type="button"
-                  onClick={() => setEditor({ property: null })}
-                  className="flex items-center gap-1.5 rounded-md py-1 text-[12px] text-faint transition-colors hover:text-muted"
-                >
-                  <Plus size={12} strokeWidth={2} />
-                  Add your first property
-                </button>
-              ) : (
-                properties.map((property) => (
+            <Plus size={13} strokeWidth={2} />
+          </button>
+        </div>
+
+        <AnimatePresence initial={false}>
+          {open && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.16, ease: EASE_OUT }}
+              className="overflow-hidden"
+            >
+              <div className="flex flex-col gap-0.5 pt-1">
+                {properties.map((property) => (
                   <div
                     key={property.key}
-                    className="group flex items-start gap-3 rounded-md px-1 py-1 text-[12.5px] transition-colors hover:bg-hover"
+                    className="group flex items-center gap-3 rounded-md px-1 py-1 text-[12.5px] transition-colors hover:bg-hover"
                   >
-                    <span className="w-24 shrink-0 truncate capitalize text-faint">
+                    <span className="w-24 shrink-0 truncate capitalize leading-5 text-faint">
                       {property.key}
                     </span>
-                    <div className="min-w-0 flex-1">
+                    <div className="flex min-h-5 min-w-0 flex-1 items-center">
                       <PropertyValue value={property.value} />
                     </div>
                     <button
@@ -97,23 +110,14 @@ export function NoteProperties({
                       <Pencil size={11} strokeWidth={1.9} />
                     </button>
                   </div>
-                ))
-              )}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-      {editor && (
-        <PropertyEditorModal
-          key={editor.property?.key ?? "new"}
-          property={editor.property}
-          existingKeys={properties.map((property) => property.key)}
-          onClose={() => setEditor(null)}
-          onSave={onUpsert}
-          onDelete={onRemove}
-        />
-      )}
-    </div>
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+      {propertyEditor}
+    </>
   );
 }
 
@@ -124,7 +128,7 @@ function PropertyValue({ value }: { value: string | string[] }) {
         {value.map((item, index) => (
           <span
             key={index}
-            className="rounded-full bg-hover px-2 py-0.5 text-[11.5px] leading-none text-muted"
+            className="rounded-full bg-hover px-2 py-0.5 text-[11.5px] leading-4 text-muted"
           >
             {item}
           </span>

--- a/src/components/editor/NoteProperties.tsx
+++ b/src/components/editor/NoteProperties.tsx
@@ -1,33 +1,61 @@
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, Pencil, Plus } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
 import type { Property } from "@/lib/frontmatter";
 import { EASE_OUT } from "@/lib/ease";
 import { cx, hostOf } from "@/lib/utils";
+import { PropertyEditorModal } from "./PropertyEditorModal";
 
-/**
- * Read-only properties panel for a note's frontmatter. Renders
- * scalars as text (URLs as links), lists as chips. Collapsible; the raw YAML
- * itself lives in the file, untouched.
- */
-export function NoteProperties({ properties }: { properties: Property[] }) {
+type EditorState = { property: Property | null } | null;
+
+export function NoteProperties({
+  properties,
+  onUpsert,
+  onRemove,
+}: {
+  properties: Property[];
+  onUpsert: (previousKey: string | null, property: Property) => void;
+  onRemove: (key: string) => void;
+}) {
   const [open, setOpen] = useState(true);
-  if (properties.length === 0) return null;
+  const [editor, setEditor] = useState<EditorState>(null);
 
   return (
     <div className="mb-5 mt-1 border-b border-line pb-3">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="mb-1 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-faint transition-colors hover:text-muted"
-      >
-        <ChevronRight
-          size={12}
-          strokeWidth={2.5}
-          className={cx("transition-transform duration-150", open && "rotate-90")}
-        />
-        Properties
-      </button>
+      <div className="mb-1 flex items-center">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-faint transition-colors hover:text-muted"
+        >
+          <ChevronRight
+            size={12}
+            strokeWidth={2.5}
+            className={cx(
+              "transition-transform duration-150",
+              open && "rotate-90",
+            )}
+          />
+          Properties
+          {properties.length > 0 && (
+            <span className="ml-0.5 font-mono text-[9.5px] font-normal tracking-normal">
+              {properties.length}
+            </span>
+          )}
+        </button>
+        <button
+          type="button"
+          aria-label="Add property"
+          title="Add property"
+          onClick={() => {
+            setOpen(true);
+            setEditor({ property: null });
+          }}
+          className="ml-auto grid h-6 w-6 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink"
+        >
+          <Plus size={13} strokeWidth={2} />
+        </button>
+      </div>
 
       <AnimatePresence initial={false}>
         {open && (
@@ -39,23 +67,52 @@ export function NoteProperties({ properties }: { properties: Property[] }) {
             className="overflow-hidden"
           >
             <div className="flex flex-col gap-0.5 pt-1">
-              {properties.map((property) => (
-                <div
-                  key={property.key}
-                  className="flex items-start gap-3 py-0.5 text-[12.5px]"
+              {properties.length === 0 ? (
+                <button
+                  type="button"
+                  onClick={() => setEditor({ property: null })}
+                  className="flex items-center gap-1.5 rounded-md py-1 text-[12px] text-faint transition-colors hover:text-muted"
                 >
-                  <span className="w-24 shrink-0 truncate capitalize text-faint">
-                    {property.key}
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <PropertyValue value={property.value} />
+                  <Plus size={12} strokeWidth={2} />
+                  Add your first property
+                </button>
+              ) : (
+                properties.map((property) => (
+                  <div
+                    key={property.key}
+                    className="group flex items-start gap-3 rounded-md px-1 py-1 text-[12.5px] transition-colors hover:bg-hover"
+                  >
+                    <span className="w-24 shrink-0 truncate capitalize text-faint">
+                      {property.key}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <PropertyValue value={property.value} />
+                    </div>
+                    <button
+                      type="button"
+                      aria-label={`Edit ${property.key}`}
+                      onClick={() => setEditor({ property })}
+                      className="grid h-5 w-5 shrink-0 place-items-center rounded text-faint opacity-0 transition-[opacity,color,background-color] hover:bg-active hover:text-ink group-hover:opacity-100 focus-visible:opacity-100"
+                    >
+                      <Pencil size={11} strokeWidth={1.9} />
+                    </button>
                   </div>
-                </div>
-              ))}
+                ))
+              )}
             </div>
           </motion.div>
         )}
       </AnimatePresence>
+      {editor && (
+        <PropertyEditorModal
+          key={editor.property?.key ?? "new"}
+          property={editor.property}
+          existingKeys={properties.map((property) => property.key)}
+          onClose={() => setEditor(null)}
+          onSave={onUpsert}
+          onDelete={onRemove}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/editor/PropertyEditorModal.tsx
+++ b/src/components/editor/PropertyEditorModal.tsx
@@ -1,9 +1,13 @@
-import { ListPlus, Trash2, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Trash2, X } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/Button";
-import { Modal } from "@/components/ui/Modal";
+import { MorphingModal } from "@/components/motion/morphing-modal";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@/components/motion/tabs";
 import { isValidPropertyKey, type Property } from "@/lib/frontmatter";
-import { cx } from "@/lib/utils";
 
 type ValueType = "text" | "list";
 
@@ -31,11 +35,6 @@ export function PropertyEditorModal({
       : (property?.value ?? ""),
   );
   const nameRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => nameRef.current?.focus());
-    return () => cancelAnimationFrame(frame);
-  }, []);
 
   const cleanName = name.trim();
   const duplicate = useMemo(
@@ -68,36 +67,34 @@ export function PropertyEditorModal({
   };
 
   return (
-    <Modal
-      open
+    <MorphingModal
+      viewId={editingKey ? "edit-property" : "add-property"}
       onClose={onClose}
+      placement="top"
       ariaLabel={editingKey ? "Edit property" : "Add property"}
-      className="w-[430px]"
+      className="max-w-[410px] rounded-xl"
     >
-      <header className="flex items-center gap-3 border-b border-line-soft px-5 py-4">
-        <div className="grid h-8 w-8 place-items-center rounded-lg bg-invert text-invert-ink">
-          <ListPlus size={15} strokeWidth={1.8} />
-        </div>
-        <div>
-          <h2 className="text-[15px] font-semibold tracking-[-0.01em]">
+      <header className="flex items-start gap-4 pb-2">
+        <div className="min-w-0">
+          <h2 className="text-[17px] font-semibold tracking-[-0.018em]">
             {editingKey ? "Edit property" : "Add property"}
           </h2>
-          <p className="mt-0.5 text-[11.5px] text-faint">
-            Stored as YAML frontmatter in this note
+          <p className="mt-1 text-[12px] leading-5 text-faint">
+            Saved as YAML frontmatter in this note
           </p>
         </div>
         <button
           type="button"
           aria-label="Close property editor"
           onClick={onClose}
-          className="ml-auto grid h-8 w-8 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink"
+          className="ml-auto -mr-1 -mt-1 grid h-8 w-8 shrink-0 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink"
         >
           <X size={15} strokeWidth={2} />
         </button>
       </header>
 
       <form
-        className="p-5"
+        className="pt-4"
         onSubmit={(event) => {
           event.preventDefault();
           submit();
@@ -109,6 +106,7 @@ export function PropertyEditorModal({
           </span>
           <input
             ref={nameRef}
+            data-autofocus
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="status"
@@ -126,69 +124,77 @@ export function PropertyEditorModal({
           </p>
         )}
 
-        <div className="mt-5">
+        <div className="mt-5 flex items-center justify-between gap-4">
           <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-faint">
             Type
           </span>
-          <div className="mt-2 grid grid-cols-2 gap-1 rounded-lg bg-panel p-1">
-            {(["text", "list"] as const).map((type) => (
-              <button
-                key={type}
-                type="button"
-                aria-pressed={valueType === type}
-                onClick={() => setValueType(type)}
-                className={cx(
-                  "rounded-md py-1.5 text-[12px] font-medium capitalize transition-colors",
-                  valueType === type
-                    ? "bg-invert text-invert-ink"
-                    : "text-muted hover:bg-hover hover:text-ink",
-                )}
-              >
-                {type}
-              </button>
-            ))}
-          </div>
+          <Tabs
+            value={valueType}
+            onValueChange={(type) => setValueType(type as ValueType)}
+            variant="segment"
+            className="inline-block"
+          >
+            <TabsList className="bg-panel p-1">
+              <TabsTrigger value="text" className="min-w-16 py-1.5 text-[12px]">
+                Text
+              </TabsTrigger>
+              <TabsTrigger value="list" className="min-w-16 py-1.5 text-[12px]">
+                List
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
         </div>
 
-        <label className="mt-5 block">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-faint">
-            Value
-          </span>
-          {valueType === "text" ? (
-            <input
-              value={value}
-              onChange={(event) => setValue(event.target.value)}
-              placeholder="active"
-              className="mt-2 h-9 w-full rounded-lg border border-line bg-panel px-3 text-[13px] text-ink outline-none transition-colors placeholder:text-faint focus:border-faint"
-            />
-          ) : (
-            <textarea
-              value={value}
-              onChange={(event) => setValue(event.target.value)}
-              placeholder={"one item per line\nsecond item"}
-              rows={4}
-              className="mt-2 w-full resize-none rounded-lg border border-line bg-panel px-3 py-2 text-[13px] leading-6 text-ink outline-none transition-colors placeholder:text-faint focus:border-faint"
-            />
-          )}
-        </label>
-        {valueType === "list" && value.length > 0 && listValues.length === 0 && (
-          <p className="mt-1.5 text-[11.5px] text-danger">
-            Add at least one list item.
-          </p>
-        )}
+        <div className="mt-5">
+          <label className="block">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-faint">
+              Value
+            </span>
+            {valueType === "text" ? (
+              <input
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                placeholder="active"
+                className="mt-2 h-9 w-full rounded-lg border border-line bg-panel px-3 text-[13px] text-ink outline-none transition-colors placeholder:text-faint focus:border-faint"
+              />
+            ) : (
+              <textarea
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                placeholder={"one item per line\nsecond item"}
+                rows={3}
+                className="mt-2 w-full resize-none rounded-lg border border-line bg-panel px-3 py-2 text-[13px] leading-6 text-ink outline-none transition-colors placeholder:text-faint focus:border-faint"
+              />
+            )}
+          </label>
+          {valueType === "list" &&
+            value.length > 0 &&
+            listValues.length === 0 && (
+              <p className="mt-1.5 text-[11.5px] text-danger">
+                Add at least one list item.
+              </p>
+            )}
+        </div>
 
-        <div className="mt-6 flex items-center gap-2 border-t border-line-soft pt-4">
+        <div className="mt-7 flex items-center gap-2">
           {editingKey && (
             <Button
               variant="danger"
               size="sm"
+              className="gap-1"
               onClick={() => {
                 onDelete(editingKey);
                 onClose();
               }}
             >
-              <Trash2 size={13} strokeWidth={1.8} />
-              Delete
+              <span className="inline-flex items-center gap-1.5 leading-4">
+                <Trash2
+                  size={13}
+                  strokeWidth={1.8}
+                  className="relative -top-px block shrink-0"
+                />
+                <span className="block leading-4">Delete</span>
+              </span>
             </Button>
           )}
           <div className="ml-auto flex items-center gap-2">
@@ -201,6 +207,6 @@ export function PropertyEditorModal({
           </div>
         </div>
       </form>
-    </Modal>
+    </MorphingModal>
   );
 }

--- a/src/components/editor/PropertyEditorModal.tsx
+++ b/src/components/editor/PropertyEditorModal.tsx
@@ -1,0 +1,206 @@
+import { ListPlus, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
+import { isValidPropertyKey, type Property } from "@/lib/frontmatter";
+import { cx } from "@/lib/utils";
+
+type ValueType = "text" | "list";
+
+export function PropertyEditorModal({
+  property,
+  existingKeys,
+  onClose,
+  onSave,
+  onDelete,
+}: {
+  property: Property | null;
+  existingKeys: string[];
+  onClose: () => void;
+  onSave: (previousKey: string | null, property: Property) => void;
+  onDelete: (key: string) => void;
+}) {
+  const editingKey = property?.key ?? null;
+  const [name, setName] = useState(property?.key ?? "");
+  const [valueType, setValueType] = useState<ValueType>(
+    Array.isArray(property?.value) ? "list" : "text",
+  );
+  const [value, setValue] = useState(
+    Array.isArray(property?.value)
+      ? property.value.join("\n")
+      : (property?.value ?? ""),
+  );
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => nameRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  const cleanName = name.trim();
+  const duplicate = useMemo(
+    () =>
+      existingKeys.some(
+        (key) =>
+          key !== editingKey &&
+          key.toLocaleLowerCase() === cleanName.toLocaleLowerCase(),
+      ),
+    [cleanName, editingKey, existingKeys],
+  );
+  const listValues = value
+    .split(/\r?\n/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const invalidName = cleanName.length > 0 && !isValidPropertyKey(cleanName);
+  const canSave =
+    cleanName.length > 0 &&
+    !invalidName &&
+    !duplicate &&
+    (valueType === "text" || listValues.length > 0);
+
+  const submit = () => {
+    if (!canSave) return;
+    onSave(editingKey, {
+      key: cleanName,
+      value: valueType === "list" ? listValues : value,
+    });
+    onClose();
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      ariaLabel={editingKey ? "Edit property" : "Add property"}
+      className="w-[430px]"
+    >
+      <header className="flex items-center gap-3 border-b border-line-soft px-5 py-4">
+        <div className="grid h-8 w-8 place-items-center rounded-lg bg-invert text-invert-ink">
+          <ListPlus size={15} strokeWidth={1.8} />
+        </div>
+        <div>
+          <h2 className="text-[15px] font-semibold tracking-[-0.01em]">
+            {editingKey ? "Edit property" : "Add property"}
+          </h2>
+          <p className="mt-0.5 text-[11.5px] text-faint">
+            Stored as YAML frontmatter in this note
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="Close property editor"
+          onClick={onClose}
+          className="ml-auto grid h-8 w-8 place-items-center rounded-md text-faint transition-colors hover:bg-hover hover:text-ink"
+        >
+          <X size={15} strokeWidth={2} />
+        </button>
+      </header>
+
+      <form
+        className="p-5"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <label className="block">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-faint">
+            Name
+          </span>
+          <input
+            ref={nameRef}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="status"
+            autoCapitalize="off"
+            autoComplete="off"
+            spellCheck={false}
+            className="mt-2 h-9 w-full rounded-lg border border-line bg-panel px-3 text-[13px] text-ink outline-none transition-colors placeholder:text-faint focus:border-faint"
+          />
+        </label>
+        {(invalidName || duplicate) && (
+          <p className="mt-1.5 text-[11.5px] text-danger">
+            {duplicate
+              ? "A property with this name already exists."
+              : "Use letters, numbers, spaces, hyphens, or underscores."}
+          </p>
+        )}
+
+        <div className="mt-5">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-faint">
+            Type
+          </span>
+          <div className="mt-2 grid grid-cols-2 gap-1 rounded-lg bg-panel p-1">
+            {(["text", "list"] as const).map((type) => (
+              <button
+                key={type}
+                type="button"
+                aria-pressed={valueType === type}
+                onClick={() => setValueType(type)}
+                className={cx(
+                  "rounded-md py-1.5 text-[12px] font-medium capitalize transition-colors",
+                  valueType === type
+                    ? "bg-invert text-invert-ink"
+                    : "text-muted hover:bg-hover hover:text-ink",
+                )}
+              >
+                {type}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <label className="mt-5 block">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-faint">
+            Value
+          </span>
+          {valueType === "text" ? (
+            <input
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              placeholder="active"
+              className="mt-2 h-9 w-full rounded-lg border border-line bg-panel px-3 text-[13px] text-ink outline-none transition-colors placeholder:text-faint focus:border-faint"
+            />
+          ) : (
+            <textarea
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              placeholder={"one item per line\nsecond item"}
+              rows={4}
+              className="mt-2 w-full resize-none rounded-lg border border-line bg-panel px-3 py-2 text-[13px] leading-6 text-ink outline-none transition-colors placeholder:text-faint focus:border-faint"
+            />
+          )}
+        </label>
+        {valueType === "list" && value.length > 0 && listValues.length === 0 && (
+          <p className="mt-1.5 text-[11.5px] text-danger">
+            Add at least one list item.
+          </p>
+        )}
+
+        <div className="mt-6 flex items-center gap-2 border-t border-line-soft pt-4">
+          {editingKey && (
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => {
+                onDelete(editingKey);
+                onClose();
+              }}
+            >
+              <Trash2 size={13} strokeWidth={1.8} />
+              Delete
+            </Button>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" size="sm" disabled={!canSave}>
+              {editingKey ? "Save" : "Add property"}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import {
   Copy,
   Download,
   FilePlus,
+  ListPlus,
   MoreVertical,
   PanelLeft,
   Pin,
@@ -229,6 +230,16 @@ export function AppShell() {
                       }}
                     />
                     <NoteMenuButton
+                      icon={ListPlus}
+                      label="Add property"
+                      onClick={() => {
+                        setNoteMenuOpen(false);
+                        if (markdownSource) toggleMarkdownSource();
+                        dispatchNoteAction("add-property");
+                      }}
+                    />
+                    <div className="mx-1 my-1 border-t border-line-soft" />
+                    <NoteMenuButton
                       icon={Download}
                       label="Export as Markdown"
                       onClick={() => {
@@ -288,7 +299,7 @@ export function AppShell() {
   );
 }
 
-type NoteAction = "export" | "copy" | "delete";
+type NoteAction = "add-property" | "export" | "copy" | "delete";
 
 function dispatchNoteAction(action: NoteAction) {
   window.dispatchEvent(

--- a/src/components/motion/morphing-modal.tsx
+++ b/src/components/motion/morphing-modal.tsx
@@ -1,0 +1,188 @@
+"use client";
+// beui.dev/components/motion/morphing-modal
+
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { type ReactNode, useEffect, useRef } from "react";
+import { EASE_OUT, SPRING_PANEL } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+export interface MorphingModalProps {
+  /** Which view is currently shown. `null` closes the modal. */
+  viewId: string | null;
+  onClose: () => void;
+  children: ReactNode;
+  /** "bottom" anchors to the viewport bottom. "center" centers vertically. */
+  placement?: "bottom" | "center" | "top";
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function MorphingModal({
+  viewId,
+  onClose,
+  children,
+  placement = "bottom",
+  className,
+  ariaLabel,
+}: MorphingModalProps) {
+  const open = viewId !== null;
+  const reduce = useReducedMotion();
+  const enterY = reduce
+    ? 0
+    : placement === "bottom"
+      ? 40
+      : placement === "top"
+        ? -12
+        : 20;
+  const enterScale = reduce ? 1 : 0.97;
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const previousOverflow = document.body.style.overflow;
+    previousFocus.current = document.activeElement as HTMLElement | null;
+    document.body.style.overflow = "hidden";
+
+    const focusable = () =>
+      Array.from(
+        panelRef.current?.querySelectorAll<HTMLElement>(
+          '[data-autofocus], button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+    const frame = requestAnimationFrame(() => focusable()[0]?.focus());
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const items = focusable();
+      if (items.length === 0) {
+        event.preventDefault();
+        panelRef.current?.focus();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+      previousFocus.current?.focus();
+    };
+  }, [onClose, open]);
+
+  return (
+    <div
+      aria-hidden={!open}
+      className={cn(
+        "fixed inset-0 z-[80]",
+        open ? "pointer-events-auto" : "pointer-events-none",
+      )}
+    >
+      <motion.button
+        type="button"
+        aria-label="Close modal"
+        initial={false}
+        animate={{ opacity: open ? 1 : 0 }}
+        transition={{ duration: 0.2, ease: EASE_OUT }}
+        onClick={onClose}
+        className={cn(
+          "absolute inset-0 bg-background/5 [backdrop-filter:blur(14px)_saturate(140%)] [-webkit-backdrop-filter:blur(14px)_saturate(140%)]",
+          open ? "pointer-events-auto" : "pointer-events-none",
+        )}
+      />
+
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-0 flex justify-center px-4",
+          placement === "bottom"
+            ? "items-end pb-8"
+            : placement === "top"
+              ? "items-start pt-[max(56px,calc(50vh-190px))]"
+              : "items-center",
+        )}
+      >
+        <AnimatePresence initial={false}>
+          {open ? (
+            <motion.div
+              ref={panelRef}
+              key="panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label={ariaLabel}
+              tabIndex={-1}
+              layout
+              initial={{ opacity: 0, y: enterY, scale: enterScale }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{
+                opacity: 0,
+                y: enterY,
+                scale: reduce ? 1 : 0.98,
+                transition: { duration: 0.18, ease: EASE_OUT },
+              }}
+              transition={SPRING_PANEL}
+              className={cn(
+                "pointer-events-auto relative w-full max-w-sm overflow-hidden rounded-3xl border border-border bg-background shadow-2xl will-change-transform",
+                className,
+              )}
+            >
+              <motion.div layout="position" className="p-5">
+                <AnimatePresence mode="popLayout" initial={false}>
+                  <motion.div
+                    key={viewId}
+                    initial={
+                      reduce
+                        ? { opacity: 0 }
+                        : { opacity: 0, y: 8, filter: "blur(4px)" }
+                    }
+                    animate={
+                      reduce
+                        ? {
+                            opacity: 1,
+                            transition: { duration: 0.18, ease: EASE_OUT },
+                          }
+                        : {
+                            opacity: 1,
+                            y: 0,
+                            filter: "blur(0px)",
+                            transition: { duration: 0.24, ease: EASE_OUT },
+                          }
+                    }
+                    exit={
+                      reduce
+                        ? {
+                            opacity: 0,
+                            transition: { duration: 0.14, ease: EASE_OUT },
+                          }
+                        : {
+                            opacity: 0,
+                            y: -8,
+                            filter: "blur(4px)",
+                            transition: { duration: 0.16, ease: EASE_OUT },
+                          }
+                    }
+                  >
+                    {children}
+                  </motion.div>
+                </AnimatePresence>
+              </motion.div>
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/src/components/motion/tabs.tsx
+++ b/src/components/motion/tabs.tsx
@@ -1,0 +1,228 @@
+"use client";
+// beui.dev/components/motion/tabs
+
+import {
+  motion,
+  MotionConfig,
+  useReducedMotion,
+  type Transition,
+} from "motion/react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { EASE_OUT } from "@/lib/ease";
+import { cn } from "@/lib/utils";
+
+type Variant = "pill" | "underline" | "segment";
+
+type Ctx = {
+  value: string;
+  setValue: (value: string) => void;
+  layoutId: string;
+  variant: Variant;
+};
+
+const TabsCtx = createContext<Ctx | null>(null);
+
+function useTabs() {
+  const context = useContext(TabsCtx);
+  if (!context) throw new Error("Tabs.* must be used inside <Tabs>");
+  return context;
+}
+
+const transition: Transition = {
+  type: "spring",
+  stiffness: 170,
+  damping: 24,
+  mass: 1.2,
+};
+
+export function Tabs({
+  defaultValue,
+  value,
+  onValueChange,
+  variant = "pill",
+  children,
+  className,
+}: {
+  defaultValue?: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  variant?: Variant;
+  children: ReactNode;
+  className?: string;
+}) {
+  const [internal, setInternal] = useState(defaultValue ?? "");
+  const layoutId = useId();
+  const reduce = useReducedMotion();
+  const controlled = value !== undefined;
+  const current = controlled ? value : internal;
+  const setValue = useCallback(
+    (next: string) => {
+      if (!controlled) setInternal(next);
+      onValueChange?.(next);
+    },
+    [controlled, onValueChange],
+  );
+  const contextValue = useMemo(
+    () => ({ value: current, setValue, layoutId, variant }),
+    [current, layoutId, setValue, variant],
+  );
+
+  return (
+    <MotionConfig transition={reduce ? { duration: 0 } : transition}>
+      <TabsCtx.Provider value={contextValue}>
+        <motion.div layoutRoot className={className}>
+          {children}
+        </motion.div>
+      </TabsCtx.Provider>
+    </MotionConfig>
+  );
+}
+
+const listClasses: Record<Variant, string> = {
+  pill: "inline-flex items-center gap-1 rounded-full bg-card p-1",
+  underline: "inline-flex items-center gap-1 border-b border-border",
+  segment: "inline-flex items-center gap-0 rounded-lg bg-card p-0.5",
+};
+
+export function TabsList({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const { variant } = useTabs();
+  return (
+    <div role="tablist" className={cn(listClasses[variant], className)}>
+      {children}
+    </div>
+  );
+}
+
+export function TabsTrigger({
+  value,
+  children,
+  className,
+  indicatorClassName,
+}: {
+  value: string;
+  children: ReactNode;
+  className?: string;
+  indicatorClassName?: string;
+}) {
+  const { value: current, setValue, layoutId, variant } = useTabs();
+  const active = current === value;
+  const usesDefaultIndicator = indicatorClassName === undefined;
+
+  if (variant === "underline") {
+    return (
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active}
+        onClick={() => setValue(value)}
+        className={cn(
+          "relative isolate -mb-px inline-flex min-h-11 items-center px-3 pb-2.5 pt-1 text-sm font-medium transition-colors",
+          active
+            ? "text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+          className,
+        )}
+      >
+        {children}
+        {active ? (
+          <motion.span
+            layoutId={layoutId}
+            className={cn(
+              "absolute -bottom-px left-0 right-0 h-px bg-primary",
+              indicatorClassName,
+            )}
+          />
+        ) : null}
+      </button>
+    );
+  }
+
+  const radius = variant === "pill" ? "rounded-full" : "rounded-md";
+
+  return (
+    <div className="relative">
+      {active ? (
+        <motion.span
+          layoutId={layoutId}
+          style={{ borderRadius: variant === "pill" ? 9999 : 8 }}
+          className={cn(
+            "absolute inset-0 bg-primary",
+            radius,
+            indicatorClassName,
+          )}
+        />
+      ) : null}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active}
+        onClick={() => setValue(value)}
+        className={cn(
+          "relative z-10 inline-flex items-center justify-center whitespace-nowrap bg-transparent px-3.5 py-1.5 text-sm font-medium outline-none",
+          usesDefaultIndicator
+            ? "text-white mix-blend-exclusion transition-opacity"
+            : "transition-colors",
+          usesDefaultIndicator
+            ? active
+              ? "opacity-100"
+              : "opacity-70 hover:opacity-100"
+            : active
+              ? "text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          radius,
+          className,
+        )}
+      >
+        {children}
+      </button>
+    </div>
+  );
+}
+
+export function TabsContent({
+  value,
+  children,
+  className,
+}: {
+  value: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const { value: current } = useTabs();
+  const reduce = useReducedMotion();
+  const active = current === value;
+
+  if (!active) {
+    return (
+      <div hidden className={className}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      key={value}
+      initial={{ opacity: 0, y: reduce ? 0 : 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.18, ease: EASE_OUT }}
+      className={cn("mt-4", className)}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -40,7 +40,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         whileTap={reduce || disabled ? undefined : { scale: 0.96 }}
         transition={SPRING_PRESS}
         className={cn(
-          "inline-flex select-none items-center justify-center font-medium transition-colors duration-100",
+          "flex select-none items-center justify-center font-medium transition-colors duration-100",
           "disabled:pointer-events-none disabled:opacity-50",
           VARIANT[variant],
           SIZE[size],

--- a/src/lib/frontmatter.ts
+++ b/src/lib/frontmatter.ts
@@ -1,8 +1,7 @@
 /**
- * YAML frontmatter handling. The app never authors frontmatter, but notes
- * clipped from external tools carry a leading `---` block. We split it off so
- * the editor shows only the body, then re-attach it verbatim on save — the file
- * keeps its metadata, the editor stays clean.
+ * YAML frontmatter handling. Frontmatter stays outside the rich editor and is
+ * re-attached on save. UI property edits only touch the selected flat property
+ * so comments and unsupported YAML structures continue to round-trip.
  */
 
 // Leading `---\n … \n---` block at the very start of the document.
@@ -35,11 +34,18 @@ export interface Property {
 }
 
 function unquote(raw: string): string {
-  return raw
-    .trim()
-    .replace(/^["']|["']$/g, "")
-    .replace(/^\[\[|\]\]$/g, "")
-    .trim();
+  const value = raw.trim();
+  if (value.startsWith('"') && value.endsWith('"')) {
+    try {
+      return JSON.parse(value) as string;
+    } catch {
+      return value.slice(1, -1);
+    }
+  }
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  return value.replace(/^\[\[|\]\]$/g, "").trim();
 }
 
 /**
@@ -83,4 +89,87 @@ export function parseFrontmatter(frontmatter: string): Property[] {
     }
   }
   return props;
+}
+
+const PROPERTY_KEY_RE = /^[A-Za-z0-9_][\w -]*$/;
+
+export function isValidPropertyKey(key: string): boolean {
+  return PROPERTY_KEY_RE.test(key.trim());
+}
+
+function propertyLines(property: Property): string[] {
+  const key = property.key.trim();
+  if (Array.isArray(property.value)) {
+    return [
+      `${key}:`,
+      ...property.value.map((item) => `  - ${JSON.stringify(item)}`),
+    ];
+  }
+  return [`${key}: ${JSON.stringify(property.value)}`];
+}
+
+function propertyRange(lines: string[], key: string, closing: number) {
+  for (let start = 1; start < closing; start += 1) {
+    const match = /^([A-Za-z0-9_][\w -]*?):[ \t]*(.*)$/.exec(lines[start]);
+    if (!match || match[1].trim() !== key) continue;
+    let end = start + 1;
+    while (end < closing && /^[ \t]*-[ \t]+/.test(lines[end])) end += 1;
+    return { start, end };
+  }
+  return null;
+}
+
+function closingDelimiterIndex(lines: string[]): number {
+  for (let index = lines.length - 1; index > 0; index -= 1) {
+    if (lines[index].trim() === "---") return index;
+  }
+  return -1;
+}
+
+/** Add or replace one flat property without reserializing the full YAML block. */
+export function upsertFrontmatterProperty(
+  frontmatter: string,
+  previousKey: string | null,
+  property: Property,
+): string {
+  const next = { ...property, key: property.key.trim() };
+  if (!isValidPropertyKey(next.key)) return frontmatter;
+
+  if (!frontmatter) {
+    return ["---", ...propertyLines(next), "---", ""].join("\n");
+  }
+
+  const newline = frontmatter.includes("\r\n") ? "\r\n" : "\n";
+  const lines = frontmatter.split(/\r?\n/);
+  const closing = closingDelimiterIndex(lines);
+  if (closing < 0) return frontmatter;
+
+  const range = propertyRange(lines, previousKey ?? next.key, closing);
+  if (range) {
+    lines.splice(range.start, range.end - range.start, ...propertyLines(next));
+  } else {
+    lines.splice(closing, 0, ...propertyLines(next));
+  }
+  return lines.join(newline);
+}
+
+/** Remove one flat property while leaving unrelated YAML untouched. */
+export function removeFrontmatterProperty(
+  frontmatter: string,
+  key: string,
+): string {
+  if (!frontmatter) return "";
+  const newline = frontmatter.includes("\r\n") ? "\r\n" : "\n";
+  const lines = frontmatter.split(/\r?\n/);
+  const closing = closingDelimiterIndex(lines);
+  if (closing < 0) return frontmatter;
+  const range = propertyRange(lines, key, closing);
+  if (!range) return frontmatter;
+
+  lines.splice(range.start, range.end - range.start);
+  const nextClosing = closingDelimiterIndex(lines);
+  const isEmpty = lines
+    .slice(1, nextClosing)
+    .every((line) => line.trim().length === 0);
+  return isEmpty ? "" : lines.join(newline);
 }

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parseFrontmatter,
+  removeFrontmatterProperty,
+  upsertFrontmatterProperty,
+} from "../src/lib/frontmatter";
+
+describe("frontmatter property editing", () => {
+  test("creates frontmatter for a new scalar property", () => {
+    expect(
+      upsertFrontmatterProperty("", null, { key: "status", value: "active" }),
+    ).toBe('---\nstatus: "active"\n---\n');
+  });
+
+  test("appends a property without changing unrelated YAML", () => {
+    const source = "---\n# clipped data\nnested:\n  name: value\n---\n";
+    expect(
+      upsertFrontmatterProperty(source, null, {
+        key: "type",
+        value: "profile",
+      }),
+    ).toBe(
+      '---\n# clipped data\nnested:\n  name: value\ntype: "profile"\n---\n',
+    );
+  });
+
+  test("renames a scalar property into a list", () => {
+    const source = "---\nstatus: active\nkeep: yes\n---\n";
+    expect(
+      upsertFrontmatterProperty(source, "status", {
+        key: "tags",
+        value: ["one", "two"],
+      }),
+    ).toBe('---\ntags:\n  - "one"\n  - "two"\nkeep: yes\n---\n');
+  });
+
+  test("removes only the selected property", () => {
+    const source = '---\ntags:\n  - "one"\n  - "two"\nkeep: yes\n---\n';
+    expect(removeFrontmatterProperty(source, "tags")).toBe(
+      "---\nkeep: yes\n---\n",
+    );
+  });
+
+  test("removes an empty frontmatter block with its last property", () => {
+    expect(removeFrontmatterProperty('---\nstatus: "active"\n---\n', "status")).toBe(
+      "",
+    );
+  });
+
+  test("parses escaped values authored by the UI", () => {
+    expect(parseFrontmatter('---\ntitle: "A \\"quoted\\" note"\n---\n')).toEqual([
+      { key: "title", value: 'A "quoted" note' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add, edit, rename, and remove text or list properties from the note UI
- preserve unrelated YAML, nested data, comments, and line endings
- keep notes without properties visually unchanged
- add the first property from the top-right note actions menu
- use beUI tabs and morphing modal primitives for property editing
- refine modal motion, alignment, focus behavior, and text clipping
- update project guidance for explicitly authored frontmatter

## Verification

- `bun test` (18 passed)
- `bunx tsc --noEmit`
- `cd src-tauri && cargo test` (40 passed)