### PR TITLE
feat: add Linux releases and downloads

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,100 @@
+name: Release Linux
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag, for example v0.1.5
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-linux-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Linux x86_64
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v6
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate release inputs
+        run: |
+          : "${TAURI_SIGNING_PRIVATE_KEY:?TAURI_SIGNING_PRIVATE_KEY is not configured}"
+          VERSION="${RELEASE_TAG#v}"
+          CONFIG_VERSION="$(node -p "require('./src-tauri/tauri.conf.json').version")"
+          test "$VERSION" = "$CONFIG_VERSION" || {
+            echo "Tag $RELEASE_TAG does not match app version $CONFIG_VERSION"
+            exit 1
+          }
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Build AppImage and Debian package
+        run: bunx tauri build --bundles appimage,deb
+
+      - name: Prepare release artifacts
+        run: |
+          APPIMAGE="$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)"
+          DEB="$(find src-tauri/target/release/bundle/deb -maxdepth 1 -name '*.deb' -print -quit)"
+          test -n "$APPIMAGE" && test -f "$APPIMAGE.sig"
+          test -n "$DEB"
+
+          mkdir -p release-artifacts
+          install -m 755 "$APPIMAGE" "release-artifacts/Markd_${VERSION}_amd64.AppImage"
+          cp "$APPIMAGE.sig" "release-artifacts/Markd_${VERSION}_amd64.AppImage.sig"
+          cp "$DEB" "release-artifacts/Markd_${VERSION}_amd64.deb"
+
+          bun scripts/generate-linux-update-manifest.js \
+            "$VERSION" \
+            "release-artifacts/Markd_${VERSION}_amd64.AppImage.sig" \
+            "release-artifacts/latest-linux.json" \
+            "Markd ${VERSION} for Linux"
+
+      - name: Keep a workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: markd-linux-${{ env.VERSION }}
+          path: release-artifacts/
+          if-no-files-found: error
+
+      - name: Upload to GitHub release
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$RELEASE_TAG" --verify-tag --generate-notes --title "Markd ${VERSION}"
+          gh release upload "$RELEASE_TAG" release-artifacts/* --clobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Markd — agent guide
 
-Local-first markdown notes app for macOS. Tauri 2 (Rust) + React 19 + Vite + Tailwind v4 + Tiptap 3 + Zustand.
+Local-first markdown notes app for macOS and GNU/Linux. Tauri 2 (Rust) + React 19 + Vite + Tailwind v4 + Tiptap 3 + Zustand.
 
 ## Commands
 
@@ -8,7 +8,8 @@ Local-first markdown notes app for macOS. Tauri 2 (Rust) + React 19 + Vite + Tai
 - `bun run build` — typecheck (tsc) + vite production build
 - `bunx tsc --noEmit` — typecheck only
 - `cd src-tauri && cargo test` — Rust unit tests
-- `bun run release` — full signed release (scripts/release.sh)
+- `bun run release`: full signed and notarized macOS release (scripts/release.sh)
+- `.github/workflows/release-linux.yml`: signed x86_64 AppImage and Debian release
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,4 +41,4 @@ See [AGENTS.md](./AGENTS.md) for the full architecture guide. The short version:
 
 ## Reporting bugs
 
-Open an issue with: macOS version, Markd version, and repro steps. If it's a vault/data issue, mention whether it reproduces with a fresh vault folder.
+Open an issue with your operating system, Markd version, and reproduction steps. If it is a vault or data issue, mention whether it reproduces with a fresh vault folder.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 **Local-first notes for people who write.**
 
-Markd is a macOS-first notes app built for developers and content creators who care about speed, privacy, and ownership.
+Markd is a fast notes app for macOS and Linux, built for people who care about speed, privacy, and ownership.
 
 No accounts.
 No cloud.
 No sync (for now).
 
-Your notes live on your Mac as plain `.md` files. Markd simply makes writing and finding them fast.
+Your notes live on your disk as plain `.md` files. Markd simply makes writing and finding them fast.
 
 ---
 
@@ -20,16 +20,35 @@ Markd releases are Developer ID signed and notarized by Apple before distributio
 
 ---
 
+## Installing on Linux
+
+Download the latest AppImage or Debian package from the [GitHub releases](https://github.com/starc007/markd/releases/latest) page.
+
+Run the AppImage:
+
+```bash
+chmod +x Markd_*_amd64.AppImage
+./Markd_*_amd64.AppImage
+```
+
+Or install the Debian package:
+
+```bash
+sudo apt install ./Markd_*_amd64.deb
+```
+
+---
+
 ## Features
 
-- **WYSIWYG markdown editor** — write in a rich editor, saved as clean markdown on disk
-- **Folders & subfolders** — organize notes in real, Finder-visible folders
-- **Todos** — a standalone task list with tags and filtering
-- **Bookmarks** — save links with auto-fetched title, image, and favicon; tag and filter them too
-- **⌘K command palette** — jump to any note, folder, or page instantly
-- **Instant search** — title + content, ranked, in milliseconds
-- **Monochrome UI** — light, dark, or system theme; no color noise
-- **Portable vault** — plain files, no IDs, no required metadata, no lock-in
+- **WYSIWYG markdown editor:** write in a rich editor, saved as clean markdown on disk
+- **Folders and subfolders:** organize notes in real, file-manager-visible folders
+- **Todos:** a standalone task list with tags and filtering
+- **Bookmarks:** save links with an auto-fetched title, image, and favicon
+- **Command palette:** press Ctrl/Cmd+K to jump to any note, folder, or page instantly
+- **Instant search:** title and content, ranked in milliseconds
+- **Monochrome UI:** light, dark, or system theme with no color noise
+- **Portable vault:** plain files, no IDs, no required metadata, no lock-in
 
 ---
 
@@ -39,17 +58,17 @@ Pick any folder on disk as your vault:
 
 ```
 <vault>/
-├── notes/          plain .md files — filename is the title, folders are real folders
+├── notes/          plain .md files, filename is the title, folders are real folders
 └── .markd/         app data: todos, bookmarks, tags, pasted images
 ```
 
-Notes are addressed by path, never by ID. Deletes go to the OS trash. Edit notes externally (vim, VS Code, whatever) — Markd picks up changes on window focus.
+Notes are addressed by path, never by ID. Deletes go to the OS trash. Edit notes externally with vim, VS Code, or another editor. Markd picks up changes on window focus.
 
 ---
 
 ## Getting started
 
-Requirements: [Bun](https://bun.sh), [Rust](https://rustup.rs), and Xcode Command Line Tools.
+Requirements: [Bun](https://bun.sh), [Rust](https://rustup.rs), and the platform dependencies listed in the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/).
 
 ```bash
 bun install
@@ -59,7 +78,7 @@ bun tauri dev      # run the app
 Build a release bundle:
 
 ```bash
-bun tauri build    # produces a .app and .dmg under src-tauri/target/release/bundle
+bun tauri build
 ```
 
 Maintainers can follow [NOTARIZATION.md](./NOTARIZATION.md) to configure Developer ID signing and Apple notarization for releases.
@@ -72,16 +91,16 @@ See [AGENTS.md](./AGENTS.md) for architecture details, or [CONTRIBUTING.md](./CO
 
 - Notes are stored locally as user-owned files
 - No analytics, tracking, accounts, or note-content uploads
-- Markd connects to `usemarkd.app` to check for application updates
+- Markd connects to `usemarkd.app` on macOS or GitHub Releases on Linux to check for application updates
 - Saving a bookmark fetches that page's title, preview image, and favicon
-- Export your notes anytime — they're already just files
+- Export your notes anytime because they are already just files
 
 ---
 
 ## Status
 
 Markd is under active development.
-Sync, encryption, and publishing may be added later — without compromising local-first performance.
+Sync, encryption, and publishing may be added later without compromising local-first performance.
 
 ## License
 

--- a/scripts/generate-latest-json.js
+++ b/scripts/generate-latest-json.js
@@ -67,7 +67,7 @@ const windowsSigPath = join(
 const linuxSigPath = join(
   buildDir,
   "appimage",
-  `${APP_NAME}_${version}_amd64.AppImage.tar.gz.sig`
+  `${APP_NAME}_${version}_amd64.AppImage.sig`
 );
 
 // Also try alternative paths (Tauri v2 might use different structure)
@@ -132,7 +132,7 @@ if (windowsSig) {
 if (linuxSig) {
   latestJson.platforms["linux-x86_64"] = {
     signature: linuxSig,
-    url: `${WEBSITE_URL}/${APP_NAME}_${version}_amd64.AppImage.tar.gz`,
+    url: `${WEBSITE_URL}/${APP_NAME}_${version}_amd64.AppImage`,
   };
   console.log("✓ Added Linux platform");
 } else {

--- a/scripts/generate-linux-update-manifest.js
+++ b/scripts/generate-linux-update-manifest.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const [version, signaturePath, outputPath, notes = `Markd ${version}`] =
+  process.argv.slice(2);
+
+if (!version || !signaturePath || !outputPath) {
+  console.error(
+    "Usage: bun scripts/generate-linux-update-manifest.js <version> <signature> <output> [notes]",
+  );
+  process.exit(1);
+}
+
+const normalizedVersion = version.replace(/^v/, "");
+const fileName = `Markd_${normalizedVersion}_amd64.AppImage`;
+const manifest = {
+  version: normalizedVersion,
+  notes,
+  pub_date: new Date().toISOString(),
+  platforms: {
+    "linux-x86_64": {
+      signature: readFileSync(resolve(signaturePath), "utf8").trim(),
+      url: `https://github.com/starc007/markd/releases/download/v${normalizedVersion}/${fileName}`,
+    },
+  },
+};
+
+const resolvedOutput = resolve(outputPath);
+mkdirSync(dirname(resolvedOutput), { recursive: true });
+writeFileSync(resolvedOutput, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`Generated ${resolvedOutput}`);

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -15,6 +15,7 @@ cloudflare-env.d.ts
 # Only latest.json (tiny, versioned) is committed; the bundles are not.
 public/downloads/*
 public/updates/*.tar.gz
+public/updates/*.AppImage
 !public/downloads/.gitkeep
 
 # TS build cache

--- a/site/app/changelog/page.tsx
+++ b/site/app/changelog/page.tsx
@@ -9,7 +9,7 @@ import { GITHUB } from "@/lib/config";
 export const metadata: Metadata = {
   title: "Changelog | Markd",
   description:
-    "See what is new in Markd, the local-first Markdown notes app for macOS.",
+    "See what is new in Markd, the local-first Markdown notes app for macOS and Linux.",
   alternates: {
     canonical: "/changelog",
   },

--- a/site/app/download/page.tsx
+++ b/site/app/download/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
-import { Apple, Terminal } from "lucide-react";
+import { Apple } from "lucide-react";
 import { Footer } from "@/components/Footer";
 import { Nav } from "@/components/Nav";
 import { DownloadLink } from "@/components/download/DownloadLink";
 import { PlatformCard } from "@/components/download/PlatformCard";
+import { LinuxIcon } from "@/components/download/PlatformIcons";
 import { DMG, LINUX_APPIMAGE, LINUX_DEB, VERSION } from "@/lib/config";
 
 export const metadata: Metadata = {
@@ -19,15 +20,15 @@ export default function DownloadPage() {
   return (
     <>
       <Nav />
-      <main className="px-5 pb-20 pt-36 sm:px-8 sm:pt-44">
+      <main className="px-5 pb-14 pt-24 sm:px-8 sm:pt-28">
         <section className="mx-auto w-full max-w-5xl text-center">
           <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-faint">
             Markd {VERSION}
           </p>
-          <h1 className="mx-auto mt-5 max-w-3xl text-balance font-serif text-[48px] leading-[0.98] tracking-[-0.035em] text-foreground sm:text-[72px]">
+          <h1 className="mx-auto mt-3 max-w-3xl text-balance font-serif text-[44px] leading-[0.98] tracking-[-0.035em] text-foreground sm:text-[56px]">
             Choose your build.
           </h1>
-          <p className="mx-auto mt-6 max-w-xl text-pretty text-[15px] leading-7 text-muted-foreground">
+          <p className="mx-auto mt-4 max-w-xl text-pretty text-[14px] leading-6 text-muted-foreground">
             The same quiet, local-first writing experience. Pick the package
             that fits your system.
           </p>
@@ -35,11 +36,11 @@ export default function DownloadPage() {
 
         <section
           aria-label="Available Markd downloads"
-          className="mx-auto mt-14 grid w-full max-w-5xl gap-4 md:grid-cols-2 sm:mt-20"
+          className="mx-auto mt-8 grid w-full max-w-5xl gap-4 md:grid-cols-2 sm:mt-10"
         >
           <PlatformCard
             index="01"
-            icon={<Apple className="size-5" strokeWidth={1.7} />}
+            icon={<Apple className="size-[18px]" strokeWidth={1.7} />}
             platform="macOS"
             architecture="Apple Silicon"
             description="A native disk image for modern Macs. Open it, move Markd to Applications, and start writing."
@@ -60,7 +61,7 @@ export default function DownloadPage() {
 
           <PlatformCard
             index="02"
-            icon={<Terminal className="size-5" strokeWidth={1.7} />}
+            icon={<LinuxIcon className="size-[18px]" />}
             platform="GNU/Linux"
             architecture="x86_64"
             description="Use the portable AppImage on most distributions, or install the Debian package on a compatible system."
@@ -86,7 +87,7 @@ export default function DownloadPage() {
           </PlatformCard>
         </section>
 
-        <p className="mx-auto mt-8 max-w-5xl text-center font-mono text-[10.5px] tracking-[0.08em] text-faint">
+        <p className="mx-auto mt-4 max-w-5xl text-center font-mono text-[10.5px] tracking-[0.08em] text-faint">
           Free and open source · No account · Your notes stay on your disk
         </p>
       </main>

--- a/site/app/download/page.tsx
+++ b/site/app/download/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import { Apple, Terminal } from "lucide-react";
+import { Footer } from "@/components/Footer";
+import { Nav } from "@/components/Nav";
+import { DownloadLink } from "@/components/download/DownloadLink";
+import { PlatformCard } from "@/components/download/PlatformCard";
+import { DMG, LINUX_APPIMAGE, LINUX_DEB, VERSION } from "@/lib/config";
+
+export const metadata: Metadata = {
+  title: "Download Markd",
+  description:
+    "Download Markd for Apple Silicon Macs or x86_64 GNU/Linux systems.",
+  alternates: {
+    canonical: "/download",
+  },
+};
+
+export default function DownloadPage() {
+  return (
+    <>
+      <Nav />
+      <main className="px-5 pb-20 pt-36 sm:px-8 sm:pt-44">
+        <section className="mx-auto w-full max-w-5xl text-center">
+          <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-faint">
+            Markd {VERSION}
+          </p>
+          <h1 className="mx-auto mt-5 max-w-3xl text-balance font-serif text-[48px] leading-[0.98] tracking-[-0.035em] text-foreground sm:text-[72px]">
+            Choose your build.
+          </h1>
+          <p className="mx-auto mt-6 max-w-xl text-pretty text-[15px] leading-7 text-muted-foreground">
+            The same quiet, local-first writing experience. Pick the package
+            that fits your system.
+          </p>
+        </section>
+
+        <section
+          aria-label="Available Markd downloads"
+          className="mx-auto mt-14 grid w-full max-w-5xl gap-4 md:grid-cols-2 sm:mt-20"
+        >
+          <PlatformCard
+            index="01"
+            icon={<Apple className="size-5" strokeWidth={1.7} />}
+            platform="macOS"
+            architecture="Apple Silicon"
+            description="A native disk image for modern Macs. Open it, move Markd to Applications, and start writing."
+            details={[
+              "macOS 12 or newer",
+              "Signed with Developer ID",
+              "Notarized by Apple",
+            ]}
+          >
+            <DownloadLink
+              href={DMG}
+              label="Download .dmg"
+              platform="macos"
+              format="dmg"
+              primary
+            />
+          </PlatformCard>
+
+          <PlatformCard
+            index="02"
+            icon={<Terminal className="size-5" strokeWidth={1.7} />}
+            platform="GNU/Linux"
+            architecture="x86_64"
+            description="Use the portable AppImage on most distributions, or install the Debian package on a compatible system."
+            details={[
+              "Portable AppImage",
+              "Debian and Ubuntu package",
+              "Signed automatic updates",
+            ]}
+          >
+            <DownloadLink
+              href={LINUX_APPIMAGE}
+              label="Download AppImage"
+              platform="linux"
+              format="appimage"
+              primary
+            />
+            <DownloadLink
+              href={LINUX_DEB}
+              label="Download .deb"
+              platform="linux"
+              format="deb"
+            />
+          </PlatformCard>
+        </section>
+
+        <p className="mx-auto mt-8 max-w-5xl text-center font-mono text-[10.5px] tracking-[0.08em] text-faint">
+          Free and open source · No account · Your notes stay on your disk
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -10,7 +10,7 @@ const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-jbmono" });
 
 const TITLE = "Markd — the last notes app you'll download";
 const DESCRIPTION =
-  "Everyone's built a notes app; few are worth keeping. Markd is a fast, local-first markdown editor for macOS — real UI, real speed, and AI that reads your notes. Plain .md files in a folder you own.";
+  "Everyone's built a notes app; few are worth keeping. Markd is a fast, local-first markdown editor for macOS and Linux, with real UI, real speed, and AI that reads your notes. Plain .md files in a folder you own.";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://usemarkd.app"),
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
   keywords: [
     "markdown notes app",
     "notes app for macOS",
+    "notes app for Linux",
     "local-first notes",
     "markdown editor mac",
     "Obsidian alternative",
@@ -49,7 +50,7 @@ const JSON_LD = {
   "@type": "SoftwareApplication",
   name: "Markd",
   applicationCategory: "ProductivityApplication",
-  operatingSystem: "macOS 12+",
+  operatingSystem: "macOS 12+, Linux x86_64",
   description: DESCRIPTION,
   url: "https://usemarkd.app",
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },

--- a/site/app/opengraph-image.tsx
+++ b/site/app/opengraph-image.tsx
@@ -50,8 +50,15 @@ export default function Image() {
             <span style={{ color: "#191917" }}>The last notes app&nbsp;</span>
             <span style={{ color: "#9c9c95" }}>you&rsquo;ll download.</span>
           </div>
-          <div style={{ display: "flex", fontSize: 30, color: "#6a6a64", maxWidth: 860 }}>
-            Local-first markdown for macOS — with AI that reads your notes.
+          <div
+            style={{
+              display: "flex",
+              fontSize: 30,
+              color: "#6a6a64",
+              maxWidth: 860,
+            }}
+          >
+            Local-first markdown for macOS and Linux, with AI that reads your notes.
           </div>
         </div>
 
@@ -66,7 +73,7 @@ export default function Image() {
           }}
         >
           <div style={{ display: "flex" }}>usemarkd.app</div>
-          <div style={{ display: "flex" }}>Free · Apple Silicon · macOS 12+</div>
+          <div style={{ display: "flex" }}>Free · macOS · Linux</div>
         </div>
       </div>
     ),

--- a/site/app/sitemap.ts
+++ b/site/app/sitemap.ts
@@ -14,5 +14,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
+    {
+      url: "https://usemarkd.app/download",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
   ];
 }

--- a/site/components/Faq.tsx
+++ b/site/components/Faq.tsx
@@ -22,8 +22,8 @@ const FAQS: { q: string; a: string }[] = [
     a: "Yes — free and open source under the MIT license. No subscription, no upsell.",
   },
   {
-    q: "Windows or Linux?",
-    a: "macOS first. Markd is built on Tauri, which is cross-platform, so other platforms may follow — but macOS is where it's polished today.",
+    q: "Which platforms are supported?",
+    a: "Markd is available for Apple Silicon Macs and x86_64 Linux systems. Linux downloads are provided as AppImage and Debian packages. Windows support may follow.",
   },
   {
     q: "What's the AI agent?",

--- a/site/components/Footer.tsx
+++ b/site/components/Footer.tsx
@@ -90,8 +90,8 @@ export function Footer() {
                 </span>
               </div>
               <p className="mt-4 text-[13.5px] leading-6 text-muted-foreground">
-                Local-first markdown notes for macOS. Your words stay on your
-                disk.
+                Local-first markdown notes for macOS and Linux. Your words stay
+                on your disk.
               </p>
             </div>
             <div className="grid grid-cols-2 gap-12 sm:gap-20">

--- a/site/components/Hero.tsx
+++ b/site/components/Hero.tsx
@@ -50,7 +50,7 @@ export function Hero() {
           className="mx-auto mt-6 max-w-xl text-pretty text-[16px] leading-7 text-muted-foreground sm:text-[18px]"
         >
           Everyone&apos;s built one; most don&apos;t survive their own v2. Markd
-          is the fast, local-first markdown editor for macOS you actually keep.
+          is the fast, local-first markdown editor you actually keep.
           Clean UI, instant everything, and AI that reads and writes your notes.
           Plain{" "}
           <code className="rounded bg-card px-1.5 py-0.5 font-mono text-[0.85em] text-fg-soft">
@@ -80,7 +80,7 @@ export function Hero() {
           {...rise(0.24)}
           className="mt-5 font-mono text-[11.5px] uppercase tracking-[0.14em] text-faint"
         >
-          Free &amp; open source · Apple Silicon · macOS 12+ · v{VERSION}
+          Free &amp; open source · macOS 12+ · Linux x86_64 · v{VERSION}
         </motion.p>
       </div>
 

--- a/site/components/download/DownloadLink.tsx
+++ b/site/components/download/DownloadLink.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Download } from "lucide-react";
+import { Apple } from "lucide-react";
 import { track } from "@/lib/analytics";
 import { VERSION } from "@/lib/config";
 import { ButtonLink } from "@/components/ui/button";
+import { LinuxIcon } from "./PlatformIcons";
 
 type DownloadLinkProps = {
   href: string;
@@ -20,6 +21,8 @@ export function DownloadLink({
   format,
   primary = false,
 }: DownloadLinkProps) {
+  const PlatformIcon = platform === "macos" ? Apple : LinuxIcon;
+
   return (
     <ButtonLink
       href={href}
@@ -28,7 +31,7 @@ export function DownloadLink({
       className="w-full sm:w-auto"
       onClick={() => track("Download", { version: VERSION, platform, format })}
     >
-      <Download className="size-4" strokeWidth={1.8} aria-hidden />
+      <PlatformIcon className="size-4" strokeWidth={1.8} aria-hidden />
       {label}
     </ButtonLink>
   );

--- a/site/components/download/DownloadLink.tsx
+++ b/site/components/download/DownloadLink.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { track } from "@/lib/analytics";
+import { VERSION } from "@/lib/config";
+import { ButtonLink } from "@/components/ui/button";
+
+type DownloadLinkProps = {
+  href: string;
+  label: string;
+  platform: "macos" | "linux";
+  format: "dmg" | "appimage" | "deb";
+  primary?: boolean;
+};
+
+export function DownloadLink({
+  href,
+  label,
+  platform,
+  format,
+  primary = false,
+}: DownloadLinkProps) {
+  return (
+    <ButtonLink
+      href={href}
+      size="md"
+      variant={primary ? "primary" : "outline"}
+      className="w-full sm:w-auto"
+      onClick={() => track("Download", { version: VERSION, platform, format })}
+    >
+      <Download className="size-4" strokeWidth={1.8} aria-hidden />
+      {label}
+    </ButtonLink>
+  );
+}

--- a/site/components/download/PlatformCard.tsx
+++ b/site/components/download/PlatformCard.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+
+type PlatformCardProps = {
+  index: string;
+  icon: ReactNode;
+  platform: string;
+  architecture: string;
+  description: string;
+  details: string[];
+  children: ReactNode;
+};
+
+export function PlatformCard({
+  index,
+  icon,
+  platform,
+  architecture,
+  description,
+  details,
+  children,
+}: PlatformCardProps) {
+  return (
+    <article className="flex min-h-[31rem] flex-col rounded-[1.75rem] border border-border bg-paper p-6 shadow-[0_18px_55px_-42px_rgba(25,25,23,0.28)] sm:p-8">
+      <div className="flex items-start justify-between">
+        <div className="grid size-12 place-items-center rounded-2xl bg-panel text-foreground">
+          {icon}
+        </div>
+        <span className="font-mono text-[10px] tracking-[0.15em] text-faint">
+          {index}
+        </span>
+      </div>
+
+      <div className="mt-10">
+        <p className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-faint">
+          {architecture}
+        </p>
+        <h2 className="mt-3 font-serif text-[38px] leading-none tracking-[-0.025em] text-foreground sm:text-[44px]">
+          {platform}
+        </h2>
+        <p className="mt-5 max-w-sm text-pretty text-[14px] leading-6 text-muted-foreground">
+          {description}
+        </p>
+      </div>
+
+      <ul className="mt-8 space-y-3 border-t border-border pt-6">
+        {details.map((detail) => (
+          <li
+            key={detail}
+            className="flex items-center gap-3 text-[12.5px] text-muted-foreground"
+          >
+            <span className="size-1 rounded-full bg-faint" aria-hidden />
+            {detail}
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-auto flex flex-col gap-2 pt-9 sm:flex-row sm:flex-wrap">
+        {children}
+      </div>
+    </article>
+  );
+}

--- a/site/components/download/PlatformCard.tsx
+++ b/site/components/download/PlatformCard.tsx
@@ -20,9 +20,9 @@ export function PlatformCard({
   children,
 }: PlatformCardProps) {
   return (
-    <article className="flex min-h-[31rem] flex-col rounded-[1.75rem] border border-border bg-paper p-6 shadow-[0_18px_55px_-42px_rgba(25,25,23,0.28)] sm:p-8">
+    <article className="flex flex-col rounded-[1.5rem] border border-border bg-paper p-5 shadow-[0_18px_55px_-42px_rgba(25,25,23,0.28)]">
       <div className="flex items-start justify-between">
-        <div className="grid size-12 place-items-center rounded-2xl bg-panel text-foreground">
+        <div className="grid size-10 place-items-center rounded-xl bg-panel text-foreground">
           {icon}
         </div>
         <span className="font-mono text-[10px] tracking-[0.15em] text-faint">
@@ -30,19 +30,19 @@ export function PlatformCard({
         </span>
       </div>
 
-      <div className="mt-10">
+      <div className="mt-5">
         <p className="font-mono text-[10.5px] uppercase tracking-[0.14em] text-faint">
           {architecture}
         </p>
-        <h2 className="mt-3 font-serif text-[38px] leading-none tracking-[-0.025em] text-foreground sm:text-[44px]">
+        <h2 className="mt-2 font-serif text-[34px] leading-none tracking-[-0.025em] text-foreground sm:text-[38px]">
           {platform}
         </h2>
-        <p className="mt-5 max-w-sm text-pretty text-[14px] leading-6 text-muted-foreground">
+        <p className="mt-3 max-w-sm text-pretty text-[13.5px] leading-6 text-muted-foreground">
           {description}
         </p>
       </div>
 
-      <ul className="mt-8 space-y-3 border-t border-border pt-6">
+      <ul className="mt-4 space-y-2 border-t border-border pt-3">
         {details.map((detail) => (
           <li
             key={detail}
@@ -54,7 +54,7 @@ export function PlatformCard({
         ))}
       </ul>
 
-      <div className="mt-auto flex flex-col gap-2 pt-9 sm:flex-row sm:flex-wrap">
+      <div className="mt-auto flex flex-col gap-2 pt-5 sm:flex-row sm:flex-wrap">
         {children}
       </div>
     </article>

--- a/site/components/download/PlatformIcons.tsx
+++ b/site/components/download/PlatformIcons.tsx
@@ -1,0 +1,19 @@
+export function LinuxIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M8.2 9.3C8 5.2 9.5 2.5 12 2.5s4 2.7 3.8 6.8c-.1 1.4.5 2.4 1.3 3.5 1 1.3 1.6 2.8 1.6 4.5 0 2.5-2.2 4.2-6.7 4.2s-6.7-1.7-6.7-4.2c0-1.7.6-3.2 1.6-4.5.8-1.1 1.4-2.1 1.3-3.5Z" />
+      <path d="M9.3 14.2c.5-1.2 1.4-1.8 2.7-1.8s2.2.6 2.7 1.8c.6 1.3.8 3.3.3 5.6" />
+      <path d="M9 8.7h.01M15 8.7h.01M10.3 10.4h3.4L12 11.6l-1.7-1.2Z" />
+      <path d="M7.7 20.6 5.4 22M16.3 20.6l2.3 1.4" />
+    </svg>
+  );
+}

--- a/site/components/ui/download-button.tsx
+++ b/site/components/ui/download-button.tsx
@@ -1,19 +1,10 @@
 "use client";
 
+import { Download } from "lucide-react";
 import { ButtonLink, type ButtonSize } from "./button";
-import { track } from "@/lib/analytics";
-import { DMG, VERSION } from "@/lib/config";
-
-function AppleLogo() {
-  return (
-    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-      <path d="M16.365 1.43c0 1.14-.42 2.2-1.12 2.98-.75.85-2 1.5-3.02 1.42-.13-1.1.42-2.27 1.08-3 .74-.82 2.05-1.42 3.06-1.4zM20.5 17.02c-.55 1.27-.81 1.83-1.52 2.95-.99 1.56-2.38 3.5-4.1 3.51-1.53.02-1.92-1-4-.99-2.07.01-2.5 1.01-4.03.99-1.72-.02-3.04-1.77-4.03-3.33-2.77-4.37-3.06-9.5-1.35-12.22 1.21-1.94 3.13-3.08 4.93-3.08 1.84 0 3 1.01 4.51 1.01 1.47 0 2.37-1.01 4.5-1.01 1.61 0 3.32.88 4.53 2.4-3.98 2.18-3.33 7.86.09 9.79z" />
-    </svg>
-  );
-}
 
 export function DownloadButton({
-  label = "Download for macOS",
+  label = "Download",
   size = "lg",
   className,
 }: {
@@ -23,14 +14,11 @@ export function DownloadButton({
 }) {
   return (
     <ButtonLink
-      href={DMG}
+      href="/download"
       size={size}
       className={className}
-      onClick={() => {
-        track("Download", { version: VERSION });
-      }}
     >
-      <AppleLogo />
+      <Download className="size-[15px]" aria-hidden />
       {label}
     </ButtonLink>
   );

--- a/site/lib/config.ts
+++ b/site/lib/config.ts
@@ -3,3 +3,5 @@ export const VERSION = "0.1.5";
 export const DMG = "/downloads/Markd_0.1.5_aarch64.dmg";
 export const GITHUB_REPO = "starc007/markd";
 export const GITHUB = `https://github.com/${GITHUB_REPO}`;
+export const LINUX_APPIMAGE = `${GITHUB}/releases/download/v${VERSION}/Markd_${VERSION}_amd64.AppImage`;
+export const LINUX_DEB = `${GITHUB}/releases/download/v${VERSION}/Markd_${VERSION}_amd64.deb`;

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -26,6 +26,18 @@ const nextConfig: NextConfig = {
           { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
         ],
       },
+      {
+        source: "/downloads/:file*.AppImage",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+        ],
+      },
+      {
+        source: "/downloads/:file*.deb",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+        ],
+      },
     ];
   },
 };

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -9,15 +9,15 @@ use crate::{backlinks, pins};
 const WELCOME: &str = r#"# Welcome to Markd
 
 A fast, local-first place to write. Every note here is a plain `.md` file in the
-folder you picked — open it in Finder, sync it with iCloud, version it with git.
+folder you picked. Open it in your file manager, sync it your way, or version it with git.
 Delete this note whenever you like.
 
 ## Try these
 
-- [ ] Press **⌘K** to jump to any note or run a command
-- [ ] Press **⌘N** to create a new note
+- [ ] Press **Ctrl/Cmd+K** to jump to any note or run a command
+- [ ] Press **Ctrl/Cmd+N** to create a new note
 - [ ] Type `[[` to link to another note
-- [ ] Press **⌘⇧D** to toggle light / dark
+- [ ] Press **Ctrl/Cmd+Shift+D** to toggle light / dark
 - [ ] Drag notes and folders in the sidebar to organize
 
 ## Markdown just works

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,8 +66,8 @@
       "icons/icon.png"
     ],
     "category": "Productivity",
-    "shortDescription": "A fast, local-first notes app for developers and content creators",
-    "longDescription": "Markd is a macOS-first, local-only, ultra high-performance notes app designed for developers and content creators who care deeply about speed, privacy, and data ownership.",
+    "shortDescription": "A fast, local-first Markdown notes app",
+    "longDescription": "Markd is a local-first Markdown notes app built for speed, privacy, and data ownership.",
     "macOS": {
       "entitlements": "./Entitlements.plist",
       "dmg": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": ["appimage", "deb"]
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/starc007/markd/releases/latest/download/latest-linux.json"
+      ]
+    }
+  }
+}

--- a/src/components/settings/SettingsPanels.tsx
+++ b/src/components/settings/SettingsPanels.tsx
@@ -1,6 +1,6 @@
 import { FolderOpen, Monitor, Moon, RefreshCw, Sun } from "lucide-react";
 import type { Theme } from "@/lib/types";
-import { cx } from "@/lib/utils";
+import { cx, isMac } from "@/lib/utils";
 import { Button } from "@/components/ui/Button";
 import { useUpdater } from "@/stores/updater";
 import { useVault } from "@/stores/vault";
@@ -14,7 +14,7 @@ const THEMES: Array<{
   {
     value: "system",
     label: "System",
-    description: "Match macOS",
+    description: "Match your system",
     icon: Monitor,
   },
   {
@@ -31,16 +31,22 @@ const THEMES: Array<{
   },
 ];
 
-const SHORTCUTS: Array<{ label: string; keys: string[] }> = [
-  { label: "Command palette", keys: ["⌘", "K"] },
-  { label: "New note", keys: ["⌘", "N"] },
-  { label: "Quick capture", keys: ["⌃", "⇧", "Space"] },
-  { label: "Today's note", keys: ["⌘", "⇧", "Y"] },
-  { label: "Toggle sidebar", keys: ["⌘", "\\"] },
-  { label: "Cycle theme", keys: ["⌘", "⇧", "D"] },
-  { label: "Settings", keys: ["⌘", ","] },
-  { label: "Close tab", keys: ["⌘", "W"] },
-];
+function shortcuts(mac: boolean): Array<{ label: string; keys: string[] }> {
+  const mod = mac ? "⌘" : "Ctrl";
+  const shift = mac ? "⇧" : "Shift";
+  const control = mac ? "⌃" : "Ctrl";
+
+  return [
+    { label: "Command palette", keys: [mod, "K"] },
+    { label: "New note", keys: [mod, "N"] },
+    { label: "Quick capture", keys: [control, shift, "Space"] },
+    { label: "Today's note", keys: [mod, shift, "Y"] },
+    { label: "Toggle sidebar", keys: [mod, "\\"] },
+    { label: "Cycle theme", keys: [mod, shift, "D"] },
+    { label: "Settings", keys: [mod, ","] },
+    { label: "Close tab", keys: [mod, "W"] },
+  ];
+}
 
 export function GeneralSettings() {
   const root = useVault((state) => state.root);
@@ -128,6 +134,8 @@ export function GeneralSettings() {
 export function AppearanceSettings() {
   const theme = useVault((state) => state.theme);
   const setTheme = useVault((state) => state.setTheme);
+  const mod = isMac() ? "⌘" : "Ctrl";
+  const shift = isMac() ? "⇧" : "Shift";
 
   return (
     <SettingsGroup
@@ -135,8 +143,8 @@ export function AppearanceSettings() {
       description="Choose how Markd looks across the editor and navigation."
       aside={
         <span className="flex items-center text-[10.5px] text-faint">
-          <Kbd>⌘</Kbd>
-          <Kbd>⇧</Kbd>
+          <Kbd>{mod}</Kbd>
+          <Kbd>{shift}</Kbd>
           <Kbd>D</Kbd>
           <span className="ml-1.5">to cycle</span>
         </span>
@@ -177,13 +185,15 @@ export function AppearanceSettings() {
 }
 
 export function ShortcutSettings() {
+  const platformShortcuts = shortcuts(isMac());
+
   return (
     <SettingsGroup
       title="Keyboard shortcuts"
       description="Fast ways to move through Markd without leaving the keyboard."
     >
       <div className="overflow-hidden rounded-xl bg-panel">
-        {SHORTCUTS.map((shortcut, index) => (
+        {platformShortcuts.map((shortcut, index) => (
           <div
             key={shortcut.label}
             className={cx(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -56,5 +56,8 @@ export function hostOf(url: string) {
 }
 
 export function isMac() {
-  return navigator.platform.toLowerCase().includes("mac");
+  return (
+    typeof navigator !== "undefined" &&
+    navigator.platform.toLowerCase().includes("mac")
+  );
 }


### PR DESCRIPTION
## Summary

- build signed x86_64 AppImage and Debian packages in GitHub Actions
- publish a Linux-specific updater manifest with each GitHub release
- add a compact download page for macOS and GNU/Linux
- route site download CTAs through the platform chooser
- use platform-aware shortcuts and generic file-manager copy

## Checks

- `bun test`
- `bunx tsc --noEmit`
- `cd site && bunx tsc --noEmit`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked`