### PR TITLE
feat: add resizable sidebar

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -42,6 +42,7 @@ import {
   MorphPopoverContent,
   MorphPopoverTrigger,
 } from "@/components/motion/popover-morph";
+import { ResizableSidebar } from "./ResizableSidebar";
 import { Sidebar } from "./Sidebar";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Tooltip } from "@/components/ui/Tooltip";
@@ -50,8 +51,6 @@ import { useTodos } from "@/stores/todos";
 import { usePins } from "@/stores/pins";
 import { useUi } from "@/stores/ui";
 import { useVault } from "@/stores/vault";
-
-const SIDEBAR_WIDTH = 240;
 
 /** Absolute on-disk path for the current view — handy to hand to an agent. */
 function viewPath(
@@ -69,9 +68,11 @@ export function AppShell() {
   const view = useVault((s) => s.view);
   const root = useVault((s) => s.root);
   const sidebarHidden = useUi((s) => s.sidebarHidden);
+  const sidebarWidth = useUi((s) => s.sidebarWidth);
   const backlinksHidden = useUi((s) => s.backlinksHidden);
   const markdownSource = useUi((s) => s.markdownSource);
   const toggleSidebar = useUi((s) => s.toggleSidebar);
+  const setSidebarWidth = useUi((s) => s.setSidebarWidth);
   const toggleBacklinks = useUi((s) => s.toggleBacklinks);
   const toggleMarkdownSource = useUi((s) => s.toggleMarkdownSource);
   const createBookmarkTag = useBookmarks((s) => s.createTag);
@@ -139,18 +140,13 @@ export function AppShell() {
 
   return (
     <div className="flex h-full bg-bg">
-      {/* Collapse by animating width (spring) with the panel clipped at a
-          fixed inner width — slides cleanly, no content reflow-jitter. */}
-      <motion.div
-        animate={{ width: sidebarHidden ? 0 : SIDEBAR_WIDTH }}
-        initial={false}
-        transition={SPRING_PANEL}
-        className="h-full shrink-0 overflow-hidden"
+      <ResizableSidebar
+        hidden={sidebarHidden}
+        width={sidebarWidth}
+        onWidthChange={setSidebarWidth}
       >
-        <div style={{ width: SIDEBAR_WIDTH }} className="h-full">
-          <Sidebar />
-        </div>
-      </motion.div>
+        <Sidebar />
+      </ResizableSidebar>
 
       <main className="relative flex min-w-0 flex-1 flex-col">
         {/* Row 1 — titlebar: sidebar toggle + open-note tabs. The strip is

--- a/src/components/layout/ResizableSidebar.tsx
+++ b/src/components/layout/ResizableSidebar.tsx
@@ -1,0 +1,117 @@
+import { motion } from "motion/react";
+import { useRef, useState } from "react";
+import { SPRING_PANEL } from "@/lib/ease";
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  sidebarWidthFromKey,
+  sidebarWidthFromPointer,
+} from "@/lib/sidebarResize";
+import { cx } from "@/lib/utils";
+
+interface ResizableSidebarProps {
+  hidden: boolean;
+  width: number;
+  onWidthChange: (width: number) => void;
+  children: React.ReactNode;
+}
+
+interface ResizeStart {
+  pointerX: number;
+  width: number;
+}
+
+export function ResizableSidebar({
+  hidden,
+  width,
+  onWidthChange,
+  children,
+}: ResizableSidebarProps) {
+  const resizeStart = useRef<ResizeStart | null>(null);
+  const [resizing, setResizing] = useState(false);
+
+  const startResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    resizeStart.current = { pointerX: event.clientX, width };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setResizing(true);
+    event.preventDefault();
+  };
+
+  const resize = (event: React.PointerEvent<HTMLDivElement>) => {
+    const start = resizeStart.current;
+    if (!start) return;
+    onWidthChange(
+      sidebarWidthFromPointer(start.width, start.pointerX, event.clientX),
+    );
+  };
+
+  const finishResize = (event: React.PointerEvent<HTMLDivElement>) => {
+    resizeStart.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setResizing(false);
+  };
+
+  const resizeWithKeyboard = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const nextWidth = sidebarWidthFromKey(width, event.key);
+    if (nextWidth === null) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onWidthChange(nextWidth);
+  };
+
+  return (
+    <motion.div
+      animate={{ width: hidden ? 0 : width }}
+      initial={false}
+      transition={resizing ? { duration: 0 } : SPRING_PANEL}
+      className={cx(
+        "relative h-full shrink-0 overflow-hidden",
+        resizing && "select-none",
+      )}
+    >
+      <div style={{ width }} className="h-full">
+        {children}
+      </div>
+
+      {!hidden && (
+        <div
+          role="separator"
+          aria-label="Resize sidebar"
+          aria-controls="markd-sidebar"
+          aria-orientation="vertical"
+          aria-valuemin={SIDEBAR_MIN_WIDTH}
+          aria-valuemax={SIDEBAR_MAX_WIDTH}
+          aria-valuenow={width}
+          aria-valuetext={`${width} pixels`}
+          tabIndex={0}
+          title="Drag to resize. Double-click to reset."
+          data-sidebar-resize-handle
+          onPointerDown={startResize}
+          onPointerMove={resize}
+          onPointerUp={finishResize}
+          onPointerCancel={finishResize}
+          onLostPointerCapture={() => {
+            resizeStart.current = null;
+            setResizing(false);
+          }}
+          onKeyDown={resizeWithKeyboard}
+          onDoubleClick={() => onWidthChange(SIDEBAR_DEFAULT_WIDTH)}
+          className="group absolute inset-y-0 right-0 z-20 w-2 cursor-col-resize touch-none outline-none"
+        >
+          <span
+            className={cx(
+              "absolute inset-y-0 right-0 w-px transition-colors duration-100",
+              resizing
+                ? "bg-ink"
+                : "bg-transparent group-hover:bg-line group-focus-visible:bg-ink",
+            )}
+          />
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -32,8 +32,9 @@ export function Sidebar() {
 
   return (
     <aside
+      id="markd-sidebar"
       data-markd-sidebar
-      className="flex h-full w-[240px] shrink-0 flex-col border-r border-line-soft bg-panel"
+      className="flex h-full w-full shrink-0 flex-col border-r border-line-soft bg-panel"
     >
       {/* drag region + traffic-light clearance */}
       <div data-tauri-drag-region className="flex h-12 items-end px-3 pb-1" />

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -4,6 +4,7 @@ import type { View } from "@/lib/types";
 import { useBookmarks } from "@/stores/bookmarks";
 import { useTabs } from "@/stores/tabs";
 import { useTodos } from "@/stores/todos";
+import { useUi } from "@/stores/ui";
 import { useVault } from "@/stores/vault";
 
 /**
@@ -16,6 +17,7 @@ interface Session {
   view: View | null;
   todoFilter: string | null;
   bookmarkFilter: string | null;
+  sidebarWidth?: number;
 }
 
 const storageKey = (root: string) => `markd:session:${root}`;
@@ -28,6 +30,7 @@ function writeSession(root: string) {
     view: vault.view,
     todoFilter: useTodos.getState().tagFilter,
     bookmarkFilter: useBookmarks.getState().tagFilter,
+    sidebarWidth: useUi.getState().sidebarWidth,
   };
   try {
     localStorage.setItem(storageKey(root), JSON.stringify(data));
@@ -58,6 +61,9 @@ export function restoreSession(root: string) {
 
   useTodos.setState({ tagFilter: data.todoFilter ?? null });
   useBookmarks.setState({ tagFilter: data.bookmarkFilter ?? null });
+  if (data.sidebarWidth !== undefined) {
+    useUi.getState().setSidebarWidth(data.sidebarWidth);
+  }
 
   const view = data.view;
   if (view?.type === "note") {
@@ -89,6 +95,9 @@ export function initSessionSync() {
   });
   useBookmarks.subscribe((s, p) => {
     if (s.tagFilter !== p.tagFilter) saveSession();
+  });
+  useUi.subscribe((s, p) => {
+    if (s.sidebarWidth !== p.sidebarWidth) saveSession();
   });
   // Flush any pending debounced save before the window goes away.
   window.addEventListener("beforeunload", () => {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,5 +1,6 @@
 import { debounce } from "@/lib/utils";
 import { flattenNotes } from "@/lib/tree";
+import { SIDEBAR_DEFAULT_WIDTH } from "@/lib/sidebarResize";
 import type { View } from "@/lib/types";
 import { useBookmarks } from "@/stores/bookmarks";
 import { useTabs } from "@/stores/tabs";
@@ -51,6 +52,9 @@ export function restoreSession(root: string) {
   } catch {
     data = null;
   }
+  useUi
+    .getState()
+    .setSidebarWidth(data?.sidebarWidth ?? SIDEBAR_DEFAULT_WIDTH);
   if (!data) return;
 
   const vault = useVault.getState();
@@ -61,9 +65,6 @@ export function restoreSession(root: string) {
 
   useTodos.setState({ tagFilter: data.todoFilter ?? null });
   useBookmarks.setState({ tagFilter: data.bookmarkFilter ?? null });
-  if (data.sidebarWidth !== undefined) {
-    useUi.getState().setSidebarWidth(data.sidebarWidth);
-  }
 
   const view = data.view;
   if (view?.type === "note") {

--- a/src/lib/sidebarResize.ts
+++ b/src/lib/sidebarResize.ts
@@ -1,0 +1,38 @@
+export const SIDEBAR_DEFAULT_WIDTH = 240;
+export const SIDEBAR_MIN_WIDTH = 200;
+export const SIDEBAR_MAX_WIDTH = 480;
+export const SIDEBAR_KEYBOARD_STEP = 16;
+
+export function clampSidebarWidth(width: number): number {
+  if (!Number.isFinite(width)) return SIDEBAR_DEFAULT_WIDTH;
+  return Math.min(
+    SIDEBAR_MAX_WIDTH,
+    Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)),
+  );
+}
+
+export function sidebarWidthFromPointer(
+  startWidth: number,
+  startPointerX: number,
+  pointerX: number,
+): number {
+  return clampSidebarWidth(startWidth + pointerX - startPointerX);
+}
+
+export function sidebarWidthFromKey(
+  width: number,
+  key: string,
+): number | null {
+  switch (key) {
+    case "ArrowLeft":
+      return clampSidebarWidth(width - SIDEBAR_KEYBOARD_STEP);
+    case "ArrowRight":
+      return clampSidebarWidth(width + SIDEBAR_KEYBOARD_STEP);
+    case "Home":
+      return SIDEBAR_MIN_WIDTH;
+    case "End":
+      return SIDEBAR_MAX_WIDTH;
+    default:
+      return null;
+  }
+}

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,4 +1,8 @@
 import { create } from "zustand";
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  clampSidebarWidth,
+} from "@/lib/sidebarResize";
 
 type SaveState = "idle" | "saving" | "error";
 export type SettingsPage = "general" | "cloud" | "appearance" | "shortcuts";
@@ -8,6 +12,7 @@ interface UiState {
   settingsOpen: boolean;
   settingsPage: SettingsPage;
   sidebarHidden: boolean;
+  sidebarWidth: number;
   backlinksHidden: boolean;
   markdownSource: boolean;
   saveState: SaveState;
@@ -16,6 +21,7 @@ interface UiState {
   openSettings: (page?: SettingsPage) => void;
   setSettingsPage: (page: SettingsPage) => void;
   toggleSidebar: () => void;
+  setSidebarWidth: (width: number) => void;
   toggleBacklinks: () => void;
   toggleMarkdownSource: () => void;
   setSaveState: (state: SaveState) => void;
@@ -26,6 +32,7 @@ export const useUi = create<UiState>((set, get) => ({
   settingsOpen: false,
   settingsPage: "general",
   sidebarHidden: false,
+  sidebarWidth: SIDEBAR_DEFAULT_WIDTH,
   backlinksHidden: true,
   markdownSource: false,
   saveState: "idle",
@@ -35,6 +42,8 @@ export const useUi = create<UiState>((set, get) => ({
     set({ settingsOpen: true, settingsPage }),
   setSettingsPage: (settingsPage) => set({ settingsPage }),
   toggleSidebar: () => set({ sidebarHidden: !get().sidebarHidden }),
+  setSidebarWidth: (sidebarWidth) =>
+    set({ sidebarWidth: clampSidebarWidth(sidebarWidth) }),
   toggleBacklinks: () => set({ backlinksHidden: !get().backlinksHidden }),
   toggleMarkdownSource: () =>
     set({ markdownSource: !get().markdownSource }),

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { restoreSession } from "../src/lib/session";
+import { SIDEBAR_DEFAULT_WIDTH } from "../src/lib/sidebarResize";
+import { useUi } from "../src/stores/ui";
+
+const items = new Map<string, string>();
+const storage: Storage = {
+  get length() {
+    return items.size;
+  },
+  clear() {
+    items.clear();
+  },
+  getItem(key) {
+    return items.get(key) ?? null;
+  },
+  key(index) {
+    return [...items.keys()][index] ?? null;
+  },
+  removeItem(key) {
+    items.delete(key);
+  },
+  setItem(key, value) {
+    items.set(key, value);
+  },
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: storage,
+});
+
+describe("session restoration", () => {
+  beforeEach(() => {
+    storage.clear();
+    useUi.getState().setSidebarWidth(360);
+  });
+
+  test("resets the width when the next vault has no saved session", () => {
+    restoreSession("/vault-b");
+
+    expect(useUi.getState().sidebarWidth).toBe(SIDEBAR_DEFAULT_WIDTH);
+  });
+
+  test("resets the width for sessions saved before width persistence", () => {
+    storage.setItem(
+      "markd:session:/legacy-vault",
+      JSON.stringify({
+        tabs: [],
+        view: null,
+        todoFilter: null,
+        bookmarkFilter: null,
+      }),
+    );
+
+    restoreSession("/legacy-vault");
+
+    expect(useUi.getState().sidebarWidth).toBe(SIDEBAR_DEFAULT_WIDTH);
+  });
+
+  test("restores a vault's saved width", () => {
+    storage.setItem(
+      "markd:session:/saved-vault",
+      JSON.stringify({
+        tabs: [],
+        view: null,
+        todoFilter: null,
+        bookmarkFilter: null,
+        sidebarWidth: 320,
+      }),
+    );
+
+    restoreSession("/saved-vault");
+
+    expect(useUi.getState().sidebarWidth).toBe(320);
+  });
+});

--- a/tests/sidebarResize.test.ts
+++ b/tests/sidebarResize.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_KEYBOARD_STEP,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  clampSidebarWidth,
+  sidebarWidthFromKey,
+  sidebarWidthFromPointer,
+} from "../src/lib/sidebarResize";
+
+describe("sidebar resizing", () => {
+  test("clamps widths to the configurable bounds", () => {
+    expect(clampSidebarWidth(SIDEBAR_MIN_WIDTH - 100)).toBe(
+      SIDEBAR_MIN_WIDTH,
+    );
+    expect(clampSidebarWidth(SIDEBAR_MAX_WIDTH + 100)).toBe(
+      SIDEBAR_MAX_WIDTH,
+    );
+    expect(clampSidebarWidth(321.6)).toBe(322);
+  });
+
+  test("falls back to the default for invalid persisted widths", () => {
+    expect(clampSidebarWidth(Number.NaN)).toBe(SIDEBAR_DEFAULT_WIDTH);
+    expect(clampSidebarWidth(Number.POSITIVE_INFINITY)).toBe(
+      SIDEBAR_DEFAULT_WIDTH,
+    );
+  });
+
+  test("derives pointer widths from the drag origin without drift", () => {
+    expect(sidebarWidthFromPointer(240, 300, 380)).toBe(320);
+    expect(sidebarWidthFromPointer(320, 380, 0)).toBe(SIDEBAR_MIN_WIDTH);
+    expect(sidebarWidthFromPointer(320, 380, 900)).toBe(SIDEBAR_MAX_WIDTH);
+  });
+
+  test("supports precise keyboard resizing and boundary shortcuts", () => {
+    expect(sidebarWidthFromKey(240, "ArrowLeft")).toBe(
+      240 - SIDEBAR_KEYBOARD_STEP,
+    );
+    expect(sidebarWidthFromKey(240, "ArrowRight")).toBe(
+      240 + SIDEBAR_KEYBOARD_STEP,
+    );
+    expect(sidebarWidthFromKey(SIDEBAR_MIN_WIDTH, "ArrowLeft")).toBe(
+      SIDEBAR_MIN_WIDTH,
+    );
+    expect(sidebarWidthFromKey(SIDEBAR_MAX_WIDTH, "ArrowRight")).toBe(
+      SIDEBAR_MAX_WIDTH,
+    );
+    expect(sidebarWidthFromKey(240, "Home")).toBe(SIDEBAR_MIN_WIDTH);
+    expect(sidebarWidthFromKey(240, "End")).toBe(SIDEBAR_MAX_WIDTH);
+    expect(sidebarWidthFromKey(240, "Enter")).toBeNull();
+  });
+
+  test("keeps the main pane usable across supported window sizes", () => {
+    const minimumMainPaneWidth = 320;
+    for (const viewportWidth of [800, 1200, 1920]) {
+      expect(viewportWidth - SIDEBAR_MAX_WIDTH).toBeGreaterThanOrEqual(
+        minimumMainPaneWidth,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a focused drag handle to the left sidebar while preserving its existing 240 px default and spring-based show/hide animation.
- Constrains resizing to centralized 200 px and 480 px bounds so both limits remain easy to adjust in `src/lib/sidebarResize.ts`.
- Supports Left/Right Arrow adjustments, Home/End boundary jumps, and double-click reset through a focusable ARIA separator.
- Persists the selected width as an optional field in the existing per-vault UI session, preserving compatibility with previously saved sessions.

## Approach

`ResizableSidebar` owns the interaction and animation boundary, keeping pointer capture and keyboard handling out of `AppShell`. Pure sizing helpers clamp every input path, including pointer movement, keyboard steps, and malformed persisted values. The sidebar itself now fills the wrapper rather than owning a second fixed width.

This keeps the editor lifecycle unchanged, adds no dependency or Rust changes, and does not affect the right-side backlinks panel or any vault/file behavior.

## Interaction and accessibility

- Pointer capture keeps the resize active if the pointer moves away from the divider.
- The resize handle exposes `role="separator"`, vertical orientation, controlled panel linkage, and live minimum/maximum/current values.
- Left/Right Arrow resize in 16 px increments; Home and End select the minimum and maximum.
- Double-click restores the 240 px default.
- The resize handle is removed from interaction while the sidebar is collapsed.

## Visual evidence

The captures use the actual React UI with deterministic Tauri IPC fixtures and a clean evidence-only vault, so no personal vault data is present.

**Default — 240 px sidebar at 1200 × 800**

<img src="https://raw.githubusercontent.com/Shreyasdbz/markd/pr-assets/resizable-sidebar/01-default-1200.png" alt="Markd with the sidebar at its 240 pixel default in a 1200 by 800 window" width="900">

**Minimum — 200 px sidebar at the supported 800 × 800 compact width**

<img src="https://raw.githubusercontent.com/Shreyasdbz/markd/pr-assets/resizable-sidebar/02-minimum-800.png" alt="Markd with the sidebar clamped to its 200 pixel minimum in an 800 by 800 window" width="600">

**Maximum — 480 px sidebar at 1920 × 800**

<img src="https://raw.githubusercontent.com/Shreyasdbz/markd/pr-assets/resizable-sidebar/03-maximum-1920.png" alt="Markd with the sidebar clamped to its 480 pixel maximum in a 1920 by 800 window" width="900">

## Verification

| Check | Result |
| --- | --- |
| Focused sidebar tests | 5 tests passed |
| Full Bun suite | 71 tests passed |
| TypeScript | `bunx tsc --noEmit` passed |
| Production frontend | `bun run build` passed |
| Rust suite | 56 tests passed |

The deterministic interaction harness also measured each end-to-end state:

| Scenario | Expected | Observed |
| --- | ---: | ---: |
| Default at 1200 px viewport | 240 px | 240 px |
| Pointer drag below minimum at 800 px viewport | 200 px | 200 px |
| Pointer drag above maximum at 1920 px viewport | 480 px | 480 px |
| Keyboard Home / lower clamp | 200 px | 200 px |
| Keyboard End / upper clamp | 480 px | 480 px |
| Double-click reset | 240 px | 240 px |
| Reload persistence | 240 px | 240 px |

Closes #16.
